### PR TITLE
feat: DT-466 Support `dev.email` trace tag

### DIFF
--- a/pkg/trace/config.go
+++ b/pkg/trace/config.go
@@ -6,7 +6,18 @@ import (
 
 // tracing config goes into trace.yaml
 type Config struct {
-	Honeycomb `yaml:"Honeycomb"`
+	Honeycomb  `yaml:"Honeycomb"`
+	GlobalTags `yaml:"GlobalTags,omitempty"`
+}
+
+type GlobalTags struct {
+	DevEmail string `yaml:"DevEmail,omitempty"`
+}
+
+func (g *GlobalTags) MarshalLog(addField func(key string, v interface{})) {
+	if g.DevEmail != "" {
+		addField("dev.email", g.DevEmail)
+	}
 }
 
 type Honeycomb struct {

--- a/pkg/trace/honeycomb.go
+++ b/pkg/trace/honeycomb.go
@@ -62,6 +62,7 @@ func (t *tracer) startHoneycombTrace(ctx context.Context, name string, prop *pro
 
 	ctx, tr := trace.NewTrace(ctx, prop)
 	marshalLog(tr.AddField, "", app.Info())
+	marshalLog(tr.AddField, "", &t.GlobalTags)
 	tr.GetRootSpan().AddField("name", name)
 	return ctx
 }


### PR DESCRIPTION
[DT-466](https://outreach-io.atlassian.net/browse/DT-466)

Updates the `trace.yaml` config file to support a new section,
`GlobalTags`.  The idea here is that `GlobalTags` will allow us to
specify in configs certain tags we would like to add to all traces.  The
`MarshalLog` implementation for the `GlobalTags` config struct will
handle converions to standardized tag names.

We start with just one attribute: `DevEmail`/`dev.email`.  This will be
injected into pods via bootstrap so that apps running in the local dev
environment will be tagged with the developer's email, making the
Honeycomb `dev` dataset much easier to navigate.

This is a forward-port of
https://github.com/getoutreach/go-outreach/pull/165.