### PR TITLE
Add error metadata for use with grpc 

### DIFF
--- a/pkg/orerr/orerr.go
+++ b/pkg/orerr/orerr.go
@@ -86,6 +86,15 @@ func WithRetry() ErrOption {
 	}
 }
 
+// WithMeta attaches the provided grpc metadata to the error.
+//
+// It is a functional option for use with New.
+func WithMeta(meta map[string]string) ErrOption {
+	return func(err error) error {
+		return Meta(err, meta)
+	}
+}
+
 // Info adds extra logging info to an error.
 func Info(err error, info ...log.Marshaler) error {
 	return withInfo{err, log.Many(info)}

--- a/pkg/orerr/orerr.go
+++ b/pkg/orerr/orerr.go
@@ -148,3 +148,29 @@ func IsOneOf(err error, errs ...error) bool {
 
 	return false
 }
+
+// Meta adds grpc metadata to an error.
+func Meta(err error, meta map[string]string) error {
+	return &withMeta{error: err, meta: meta}
+}
+
+type withMeta struct {
+	error
+	meta map[string]string
+}
+
+// Unwrap returns the underlying error.
+// This method is required by errors.Unwrap.
+func (e *withMeta) Unwrap() error {
+	return e.error
+}
+
+// ExtractErrorMetadata returns any embedded grpc metadata in
+func ExtractErrorMetadata(err error) map[string]string {
+	var m *withMeta
+	if errors.As(err, &m) {
+		return m.meta
+	}
+
+	return map[string]string{}
+}

--- a/pkg/orerr/orerr.go
+++ b/pkg/orerr/orerr.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/getoutreach/gobox/pkg/log"
+	"github.com/getoutreach/gobox/pkg/statuscodes"
 )
 
 // A SentinelError is a constant which ought to be compared using errors.Is.
@@ -92,6 +93,15 @@ func WithRetry() ErrOption {
 func WithMeta(meta map[string]string) ErrOption {
 	return func(err error) error {
 		return Meta(err, meta)
+	}
+}
+
+// WithStatus calls NewErrorStatus with the given code.
+//
+// It is a functional option for use with New.
+func WithStatus(code statuscodes.StatusCode) ErrOption {
+	return func(err error) error {
+		return NewErrorStatus(err, code)
 	}
 }
 

--- a/pkg/orerr/orerr_test.go
+++ b/pkg/orerr/orerr_test.go
@@ -111,3 +111,19 @@ func (suite) TestLimitExceededError(t *testing.T) {
 	assert.Assert(t, errors.Is(limitErr, err))
 	assert.Equal(t, limitErr.Error(), "queue limit exceeded")
 }
+
+func (suite) TestExtractErrorMetadata(t *testing.T) {
+	origErr := errors.New("something went wrong")
+	err := orerr.Meta(origErr, map[string]string{
+		"my-service-status-code": "xxx",
+	})
+
+	assert.DeepEqual(t, orerr.ExtractErrorMetadata(err), map[string]string{
+		"my-service-status-code": "xxx",
+	})
+}
+
+func (suite) TestExtractMetadataErrorEmpty(t *testing.T) {
+	err := errors.New("something went wrong")
+	assert.Equal(t, len(orerr.ExtractErrorMetadata(err)), 0)
+}

--- a/pkg/orerr/orerr_test.go
+++ b/pkg/orerr/orerr_test.go
@@ -114,13 +114,10 @@ func (suite) TestLimitExceededError(t *testing.T) {
 
 func (suite) TestExtractErrorMetadata(t *testing.T) {
 	origErr := errors.New("something went wrong")
-	err := orerr.Meta(origErr, map[string]string{
-		"my-service-status-code": "xxx",
-	})
+	meta := map[string]string{"my-service-status-code": "xxx"}
 
-	assert.DeepEqual(t, orerr.ExtractErrorMetadata(err), map[string]string{
-		"my-service-status-code": "xxx",
-	})
+	err := orerr.Meta(origErr, meta)
+	assert.DeepEqual(t, orerr.ExtractErrorMetadata(err), meta)
 }
 
 func (suite) TestExtractMetadataErrorEmpty(t *testing.T) {


### PR DESCRIPTION
This adds a new error type that embeds metadata, which must be of type `map[string]string` in order to be used with the [errdetails.ErrorInfo](https://pkg.go.dev/google.golang.org/genproto@v0.0.0-20210708141623-e76da96a951f/googleapis/rpc/errdetails#ErrorInfo) type.

This is meant to support https://github.com/getoutreach/services/pull/134