### PR TITLE
feat: VI-3634 add AZURE_BENTO env

### DIFF
--- a/pkg/app/info.go
+++ b/pkg/app/info.go
@@ -70,9 +70,13 @@ func info() *Data {
 	// well enough for now.
 	serviceID := fmt.Sprintf("%s@outreach.cloud", appName)
 
-	parts := strings.Split(namespace, "--")
-	if len(parts) == 2 {
-		bento = parts[1]
+	if ab := os.Getenv("AZURE_BENTO"); ab != "" {
+		bento = ab
+	} else {
+		parts := strings.Split(namespace, "--")
+		if len(parts) == 2 {
+			bento = parts[1]
+		}
 	}
 
 	environment := unknown

--- a/pkg/app/info.go
+++ b/pkg/app/info.go
@@ -70,13 +70,19 @@ func info() *Data {
 	// well enough for now.
 	serviceID := fmt.Sprintf("%s@outreach.cloud", appName)
 
+	parts := strings.Split(namespace, "--")
+	if len(parts) == 2 {
+		bento = parts[1]
+	}
+
+	// Bootstrpped service has this assumption about the naming of namespace where
+	// this service should be hosted, i.e it should be <service>--<bento>.
+	// However, this creates a problem for azure clusters where we don't have a
+	// bento concept. For azure, specify this environment variable will override
+	// the bento name such that an azure service, like transcription-frontdoor can
+	// talk to a bootstrapped service which is deployed in azure cluster.
 	if ab := os.Getenv("AZURE_BENTO"); ab != "" {
 		bento = ab
-	} else {
-		parts := strings.Split(namespace, "--")
-		if len(parts) == 2 {
-			bento = parts[1]
-		}
 	}
 
 	environment := unknown


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 
We're trying to deploy mint in azure. The main blocker is that azure doesn't have such bento/namespace convention. This causes all sort of hack, like transcription-frontdoor (in namespace `rolling`) needs to lie about the namespace it's in such that it can talk to mint in mint--dev-westus2 namespace, and had to create an empty namespace (like `frontdoor--dev-westus2`) just to host a serviceaccount, such that mint can query k8s api to get the annotation of that sa account.

This relaxes the requirement of bento naming convention and solve this problem.

<!--- Block(jiraPrefix) --->
**JIRA ID**: [VI-3634]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:

<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[VI-3634]: https://outreach-io.atlassian.net/browse/VI-3634