### PR TITLE
feat(box): allow enabling/disabling runtimes for the devenv

### DIFF
--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -41,6 +41,9 @@ type DeveloperEnvironmentConfig struct {
 // DeveloperEnvironmentRuntimeConfig stores configuration specific to
 // different runtimes.
 type DeveloperEnvironmentRuntimeConfig struct {
+	// EnabledRuntimes dictates which runtimes are enabled, generally defaults to all.
+	EnabledRuntimes []string `yaml:"enabledRuntimes"`
+
 	// Loft is configuration for the loft runtime in the devenv
 	Loft *LoftRuntimeConfig `yaml:"loft"`
 }


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: As the tile says, it does. This allows granular control over which runtimes are enabled for a devenv. This is useful because they are all ran to detect which is running, so if someone didn't have one disabled it could potentially be ran/downloaded for no reason.

<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-775]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:

<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-775]: https://outreach-io.atlassian.net/browse/DTSS-775