### PR TITLE
feat(exec): add ResolveExecutable

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -1,0 +1,24 @@
+// Package exec implements os/exec stdlib helpers
+package exec
+
+import (
+	"os/exec"
+	"path/filepath"
+)
+
+// ResolveExecutable find the absolute path to a given binary.
+// This is meant to be used with os.Args[0]
+func ResolveExecuable(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+
+	// if we're not a path, e.g. devenv then look it up
+	// in PATH
+	if dir, _ := filepath.Split(path); dir == "" {
+		return exec.LookPath(path)
+	}
+
+	// otherwise we should just return the absolute path (resolve it)
+	return filepath.Abs(path)
+}

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -1,0 +1,76 @@
+// Package exec implements os/exec stdlib helpers
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func getCwd() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	return dir
+}
+
+func TestResolveExecuable(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "should lookup path",
+			args: args{
+				path: "true",
+			},
+			want: filepath.Join(string(filepath.Separator), "usr", "bin", "true"),
+		},
+		{
+			name: "should return abs path",
+			args: args{
+				path: "/hello/world/devenv",
+			},
+			want: filepath.Join(string(filepath.Separator), "hello", "world", "devenv"),
+		},
+		{
+			name: "should clean abs path",
+			args: args{
+				path: "/hello/world/../devenv",
+			},
+			want: filepath.Join(string(filepath.Separator), "hello", "devenv"),
+		},
+		{
+			name: "should make abs path",
+			args: args{
+				path: "./devenv",
+			},
+			want: filepath.Join(getCwd(), "devenv"),
+		},
+		{
+			name: "should make abs path 2",
+			args: args{
+				path: "./hello/world/devenv",
+			},
+			want: filepath.Join(getCwd(), "hello", "world", "devenv"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveExecuable(tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveExecuable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ResolveExecuable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds a new `exec` package for helpers around `os/exec`. This specifically adds `ResolveExecuable` meant for usage with `os.Args[0]` to return a absolute path to the current executable


<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-0]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
