### PR TITLE
feat: add log marshallers args to span

### DIFF
--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -165,7 +165,7 @@ func StartTrace(ctx context.Context, name string) context.Context {
 // Use trace.End to end this.
 func StartSpan(ctx context.Context, name string, args ...log.Marshaler) context.Context {
 	newCtx := defaultTracer.startSpan(ctx, name)
-	addDefaultTracerInfo(ctx, args...)
+	addDefaultTracerInfo(newCtx, args...)
 	return newCtx
 }
 

--- a/pkg/trace/trace_test.go
+++ b/pkg/trace/trace_test.go
@@ -32,11 +32,11 @@ func (suite) TestNestedSpan(t *testing.T) {
 	ctx := trace.StartTrace(context.Background(), "trace-test")
 	trace.AddInfo(ctx, log.F{"trace": "outermost"})
 
-	inner := trace.StartSpan(ctx, "inner")
+	inner := trace.StartSpan(ctx, "inner", log.F{"from": "inner_span"})
 	trace.AddInfo(inner, log.F{"trace": "inner"})
 
 	inner2 := trace.StartSpan(inner, "inner2")
-	trace.AddInfo(inner2, log.F{"trace": "inner2"})
+	trace.AddSpanInfo(inner2, log.F{"trace": "inner2"})
 
 	trace.End(inner2)
 	trace.End(inner)
@@ -64,6 +64,7 @@ func (suite) TestNestedSpan(t *testing.T) {
 			"app.name":             "gobox",
 			"app.version":          "testing",
 			"duration_ms":          differs.FloatRange(0, 2),
+			"from":                 "inner_span",
 			"meta.beeline_version": differs.AnyString(),
 			"meta.local_hostname":  differs.AnyString(),
 			"meta.span_type":       "leaf",
@@ -118,7 +119,7 @@ func (suite) TestTrace(t *testing.T) {
 	if span == nil || span.GetParent() != nil {
 		t.Fatal("Did not create a root span")
 	}
-	trace.AddInfo(ctx2, log.F{"inner": "inner"})
+	trace.AddSpanInfo(ctx2, log.F{"inner": "inner"})
 	trace.End(ctx2)
 	trace.AddInfo(ctx, log.F{"outer": "outer"})
 	trace.End(ctx)


### PR DESCRIPTION
## What this PR does / why we need it

Right now if we are using StartSpan, we have no way to add additional info to the span, without directly referencing the honeycomb library.  This change brings it up to parity with StartCall

**JIRA ID**: [XX-XX]
