### PR TITLE
feat: log context

### DIFF
--- a/pkg/log/all_test.go
+++ b/pkg/log/all_test.go
@@ -3,9 +3,11 @@ package log_test
 import (
 	"testing"
 
+	"github.com/getoutreach/gobox/pkg/log"
 	"github.com/getoutreach/gobox/pkg/shuffler"
 )
 
 func TestAll(t *testing.T) {
+	log.AllowContextFields("context.string", "context.number", "or.org.guid", "or.org.shortname")
 	shuffler.Run(t, fatalSuite{}, withSuite{}, callerSuite{}, logContextSuite{})
 }

--- a/pkg/log/all_test.go
+++ b/pkg/log/all_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestAll(t *testing.T) {
-	shuffler.Run(t, fatalSuite{}, withSuite{}, callerSuite{})
+	shuffler.Run(t, fatalSuite{}, withSuite{}, callerSuite{}, logContextSuite{})
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -129,19 +129,19 @@ func (f F) MarshalLog(addField func(field string, value interface{})) {
 // Debug emits a log at DEBUG level but only if an error or fatal happens
 // within 2min of this event
 func Debug(ctx context.Context, message string, m ...Marshaler) {
-	dbgEntries.Append(format(message, "DEBUG", time.Now(), app.Info(), m))
+	dbgEntries.Append(format(message, "DEBUG", time.Now(), app.Info(), m, getLogInfo(ctx)))
 }
 
 // Info emits a log at INFO level. This is not filtered and meant for non-debug information.
 func Info(ctx context.Context, message string, m ...Marshaler) {
-	s := format(message, "INFO", time.Now(), app.Info(), m)
+	s := format(message, "INFO", time.Now(), app.Info(), m, getLogInfo(ctx))
 
 	Write(s)
 }
 
 // Warn emits a log at WARN level. Warn logs are meant to be investigated if they reach high volumes.
 func Warn(ctx context.Context, message string, m ...Marshaler) {
-	s := format(message, "WARN", time.Now(), app.Info(), m)
+	s := format(message, "WARN", time.Now(), app.Info(), m, getLogInfo(ctx))
 
 	Write(s)
 }
@@ -149,7 +149,7 @@ func Warn(ctx context.Context, message string, m ...Marshaler) {
 // Error emits a log at ERROR level.  Error logs must be investigated
 func Error(ctx context.Context, message string, m ...Marshaler) {
 	dbgEntries.Flush(Write)
-	s := format(message, "ERROR", time.Now(), app.Info(), m)
+	s := format(message, "ERROR", time.Now(), app.Info(), m, getLogInfo(ctx))
 
 	Write(s)
 }
@@ -157,15 +157,19 @@ func Error(ctx context.Context, message string, m ...Marshaler) {
 // Fatal emits a log at FATAL level and exits.  This is for catastrophic unrecoverable errors.
 func Fatal(ctx context.Context, message string, m ...Marshaler) {
 	dbgEntries.Flush(Write)
-	s := format(message, "FATAL", time.Now(), app.Info(), m)
+	s := format(message, "FATAL", time.Now(), app.Info(), m, getLogInfo(ctx))
 
 	Write(s)
 
 	os.Exit(1)
 }
 
-func format(msg, level string, ts time.Time, appInfo Marshaler, mm Many) string {
+func format(msg, level string, ts time.Time, appInfo Marshaler, mm Many, logInfo Marshaler) string {
 	entry := F{"message": msg, "level": level, "@timestamp": ts.Format(time.RFC3339Nano)}
+
+	if logInfo != nil {
+		logInfo.MarshalLog(entry.Set)
+	}
 
 	appInfo.MarshalLog(entry.Set)
 	mm.MarshalLog(entry.Set)

--- a/pkg/log/log_context.go
+++ b/pkg/log/log_context.go
@@ -37,7 +37,7 @@ func filterAllowList(info F) F {
 }
 
 // nolint:gochecknoglobals
-var infoKey = &F{}
+var infoKey = "54be8dc9-91ac-4f77-b90a-70e1ffd74566" //random guid
 
 // Creates a new Value context to store fields that should be attached to all logs
 func NewContext(ctx context.Context) context.Context {
@@ -45,7 +45,12 @@ func NewContext(ctx context.Context) context.Context {
 		return ctx
 	}
 
-	return context.WithValue(ctx, infoKey, &F{})
+	// we use a guid string to avoid versioning issues, should not have collisions
+	return context.WithValue(ctx, infoKey, &F{}) //nolint:revive, staticcheck
+}
+
+type fieldsSet interface {
+	Set(field string, value interface{})
 }
 
 // Add arguments to all logs. Return true if this is a log info context after args are added
@@ -55,7 +60,7 @@ func NewContext(ctx context.Context) context.Context {
 // If the current context is not the log info contex, AddInfo does nothing and return false.
 func AddInfo(ctx context.Context, args ...Marshaler) {
 	if infoKeyVal := ctx.Value(infoKey); infoKeyVal != nil {
-		logInfo := infoKeyVal.(*F)
+		logInfo := infoKeyVal.(fieldsSet)
 		temp := F{}
 		many := Many(args)
 		many.MarshalLog(temp.Set)
@@ -66,7 +71,7 @@ func AddInfo(ctx context.Context, args ...Marshaler) {
 
 func getLogInfo(ctx context.Context) Marshaler {
 	if infoKeyVal := ctx.Value(infoKey); infoKeyVal != nil {
-		logInfo := infoKeyVal.(*F)
+		logInfo := infoKeyVal.(Marshaler)
 		return logInfo
 	}
 

--- a/pkg/log/log_context.go
+++ b/pkg/log/log_context.go
@@ -6,7 +6,7 @@ import (
 
 var allowList map[string]bool
 
-func SetAllowedLogContextFields(fields ...string) {
+func AllowContextFields(fields ...string) {
 	if allowList != nil {
 		panic("the log context fields allowed list can only be set once")
 	}

--- a/pkg/log/log_context.go
+++ b/pkg/log/log_context.go
@@ -36,19 +36,20 @@ func filterAllowList(info F) F {
 	return result
 }
 
-// nolint:gochecknoglobals
-var infoKey = "54be8dc9-91ac-4f77-b90a-70e1ffd74566" //random guid
+type logContextKeyType int
+
+const currentLogContextKey logContextKeyType = iota
 
 // Creates a new Value context to store fields that should be attached to all logs
 // MarshalLog is invoked immediately on all args to reduce risk of hard to debug issues
 // and arbitrary code running during logging.
 func NewContext(ctx context.Context, args ...Marshaler) context.Context {
 	returnCtx := ctx
-	infoKeyVal := ctx.Value(infoKey)
+	infoKeyVal := ctx.Value(currentLogContextKey)
 	if infoKeyVal == nil {
 		infoKeyVal = &F{}
 		// we use a guid string to avoid versioning issues, should not have collisions
-		returnCtx = context.WithValue(ctx, infoKey, infoKeyVal) //nolint:revive, staticcheck
+		returnCtx = context.WithValue(ctx, currentLogContextKey, infoKeyVal) //nolint:revive, staticcheck
 	}
 
 	logInfo := infoKeyVal.(fieldsSet)
@@ -65,7 +66,7 @@ type fieldsSet interface {
 }
 
 func getLogInfo(ctx context.Context) Marshaler {
-	if infoKeyVal := ctx.Value(infoKey); infoKeyVal != nil {
+	if infoKeyVal := ctx.Value(currentLogContextKey); infoKeyVal != nil {
 		logInfo := infoKeyVal.(Marshaler)
 		return logInfo
 	}

--- a/pkg/log/log_context.go
+++ b/pkg/log/log_context.go
@@ -2,81 +2,23 @@ package log
 
 import (
 	"context"
-	"fmt"
 )
 
-type logInfo struct {
-	Fields map[string]interface{}
-}
+var allowList map[string]bool
 
-func (li *logInfo) MarshalLog(addField func(field string, value interface{})) {
-	if li == nil {
-		return
+func SetAllowedLogContextFields(fields ...string) {
+	if allowList != nil {
+		panic("the log context fields allowed list can only be set once")
 	}
 
-	for k, v := range li.Fields {
-		addField(k, v)
+	allowList = map[string]bool{}
+	for _, v := range fields {
+		allowList[v] = true
 	}
-}
-
-func (li *logInfo) addField(key string, v interface{}) {
-	if li == nil {
-		return
-	}
-
-	li.Fields[key] = convertValue(v)
-}
-
-func (li *logInfo) addArgFields(args []Marshaler) {
-	for _, arg := range args {
-		arg.MarshalLog(li.addField)
-	}
-}
-
-func convertValue(v interface{}) interface{} {
-	switch val := v.(type) {
-	case string:
-		return val
-	case []byte:
-		return val
-	case bool:
-		return val
-	case int:
-		return val
-	case int8:
-		return val
-	case int16:
-		return val
-	case int32:
-		return val
-	case int64:
-		return val
-	case uint:
-		return val
-	case uint8:
-		return val
-	case uint16:
-		return val
-	case uint32:
-		return val
-	case uint64:
-		return val
-	case float32:
-		return val
-	case float64:
-		return val
-	default:
-		vStringer, ok := v.(fmt.Stringer)
-		if ok {
-			return vStringer.String()
-		}
-	}
-
-	panic("try to add unsupported field to call info")
 }
 
 // nolint:gochecknoglobals
-var infoKey = &logInfo{}
+var infoKey = &F{}
 
 // Creates a new Value context to store fields that should be attached to all logs
 func NewLogContext(ctx context.Context) context.Context {
@@ -84,9 +26,7 @@ func NewLogContext(ctx context.Context) context.Context {
 		return ctx
 	}
 
-	return context.WithValue(ctx, infoKey, &logInfo{
-		Fields: map[string]interface{}{},
-	})
+	return context.WithValue(ctx, infoKey, &F{})
 }
 
 // Add arguments to all logs. Return true if this is a log info context after args are added
@@ -94,19 +34,26 @@ func NewLogContext(ctx context.Context) context.Context {
 // and arbitrary code running during logging.
 //
 // If the current context is not the log info contex, AddInfo does nothing and return false.
-func AddInfo(ctx context.Context, args ...Marshaler) bool {
+func AddInfo(ctx context.Context, args ...Marshaler) {
 	if infoKeyVal := ctx.Value(infoKey); infoKeyVal != nil {
-		logInfo := infoKeyVal.(*logInfo)
-		logInfo.addArgFields(args)
-		return true
+		logInfo := infoKeyVal.(*F)
+		many := Many(args)
+		set := logInfo.Set
+		if allowList != nil {
+			set = func(field string, value interface{}) {
+				_, ok := allowList[field]
+				if ok {
+					logInfo.Set(field, value)
+				}
+			}
+		}
+		many.MarshalLog(set)
 	}
-
-	return false
 }
 
 func getLogInfo(ctx context.Context) Marshaler {
 	if infoKeyVal := ctx.Value(infoKey); infoKeyVal != nil {
-		logInfo := infoKeyVal.(*logInfo)
+		logInfo := infoKeyVal.(*F)
 		return logInfo
 	}
 

--- a/pkg/log/log_context.go
+++ b/pkg/log/log_context.go
@@ -1,0 +1,114 @@
+package log
+
+import (
+	"context"
+	"fmt"
+)
+
+type logInfo struct {
+	Fields map[string]interface{}
+}
+
+func (li *logInfo) MarshalLog(addField func(field string, value interface{})) {
+	if li == nil {
+		return
+	}
+
+	for k, v := range li.Fields {
+		addField(k, v)
+	}
+}
+
+func (li *logInfo) addField(key string, v interface{}) {
+	if li == nil {
+		return
+	}
+
+	li.Fields[key] = convertValue(v)
+}
+
+func (li *logInfo) addArgFields(args []Marshaler) {
+	for _, arg := range args {
+		arg.MarshalLog(li.addField)
+	}
+}
+
+func convertValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case string:
+		return val
+	case []byte:
+		return val
+	case bool:
+		return val
+	case int:
+		return val
+	case int8:
+		return val
+	case int16:
+		return val
+	case int32:
+		return val
+	case int64:
+		return val
+	case uint:
+		return val
+	case uint8:
+		return val
+	case uint16:
+		return val
+	case uint32:
+		return val
+	case uint64:
+		return val
+	case float32:
+		return val
+	case float64:
+		return val
+	default:
+		vStringer, ok := v.(fmt.Stringer)
+		if ok {
+			return vStringer.String()
+		}
+	}
+
+	panic("try to add unsupported field to call info")
+}
+
+// nolint:gochecknoglobals
+var infoKey = &logInfo{}
+
+// Creates a new Value context to store fields that should be attached to all logs
+func NewLogContext(ctx context.Context) context.Context {
+	if infoKeyVal := ctx.Value(infoKey); infoKeyVal != nil {
+		return ctx
+	}
+
+	return context.WithValue(ctx, infoKey, &logInfo{
+		Fields: map[string]interface{}{},
+	})
+}
+
+// Add arguments to all logs. Return true if this is a log info context after args are added
+// MarshalLog is invokved immediately on all args to reduce risk of hard to debug issues
+// and arbitrary code running during logging.
+//
+// If the current context is not the log info contex, AddInfo does nothing and return false.
+func AddInfo(ctx context.Context, args ...Marshaler) bool {
+	if infoKeyVal := ctx.Value(infoKey); infoKeyVal != nil {
+		logInfo := infoKeyVal.(*logInfo)
+		logInfo.addArgFields(args)
+		return true
+	}
+
+	return false
+}
+
+func getLogInfo(ctx context.Context) Marshaler {
+	if infoKeyVal := ctx.Value(infoKey); infoKeyVal != nil {
+		logInfo := infoKeyVal.(*logInfo)
+		return logInfo
+	}
+
+	return nil
+}

--- a/pkg/log/log_context.go
+++ b/pkg/log/log_context.go
@@ -69,7 +69,7 @@ func NewContext(ctx context.Context) context.Context {
 }
 
 // Add arguments to all logs. Return true if this is a log info context after args are added
-// MarshalLog is invokved immediately on all args to reduce risk of hard to debug issues
+// MarshalLog is invoked immediately on all args to reduce risk of hard to debug issues
 // and arbitrary code running during logging.
 //
 // If the current context is not the log info contex, AddInfo does nothing and return false.

--- a/pkg/log/log_context.go
+++ b/pkg/log/log_context.go
@@ -28,7 +28,7 @@ func AllowContextFields(fields ...string) {
 func filterAllowList(info F, allow map[string]interface{}) F {
 	result := F{}
 	if allow == nil {
-		return info
+		panic("AllowContextFields must be set in order to use log.Context")
 	}
 
 	for k, v := range info {

--- a/pkg/log/log_context.go
+++ b/pkg/log/log_context.go
@@ -21,7 +21,7 @@ func AllowContextFields(fields ...string) {
 var infoKey = &F{}
 
 // Creates a new Value context to store fields that should be attached to all logs
-func NewLogContext(ctx context.Context) context.Context {
+func NewContext(ctx context.Context) context.Context {
 	if infoKeyVal := ctx.Value(infoKey); infoKeyVal != nil {
 		return ctx
 	}

--- a/pkg/log/log_context_test.go
+++ b/pkg/log/log_context_test.go
@@ -23,7 +23,8 @@ func (logContextSuite) TestLogContext(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = log.NewLogContext(ctx)
-	log.AddInfo(ctx, log.F{"context.string": "test", "context.number": 5, "context.suite": logContextSuite{}})
+	log.SetAllowedLogContextFields("context.string", "context.number")
+	log.AddInfo(ctx, log.F{"context.string": "test", "context.number": 5, "foo": "not_allowed"})
 	log.Debug(ctx, "Debug message", log.F{"some": "thing"})
 	log.Info(ctx, "Info message", log.F{"some": "thing"})
 	log.Warn(ctx, "Warn message", log.F{"some": "thing"})
@@ -32,40 +33,36 @@ func (logContextSuite) TestLogContext(t *testing.T) {
 	expected := []log.F{
 		{
 			"@timestamp":     differs.RFC3339NanoTime(),
-			"app.version":    "testing",
+			"app.version":    differs.AnyString(),
 			"context.string": "test",
 			"context.number": float64(5),
-			"context.suite":  "logContextSuite",
 			"level":          "INFO",
 			"message":        "Info message",
 			"some":           "thing",
 		},
 		{
 			"@timestamp":     differs.RFC3339NanoTime(),
-			"app.version":    "testing",
+			"app.version":    differs.AnyString(),
 			"context.string": "test",
 			"context.number": float64(5),
-			"context.suite":  "logContextSuite",
 			"level":          "WARN",
 			"message":        "Warn message",
 			"some":           "thing",
 		},
 		{
 			"@timestamp":     differs.RFC3339NanoTime(),
-			"app.version":    "testing",
+			"app.version":    differs.AnyString(),
 			"context.string": "test",
 			"context.number": float64(5),
-			"context.suite":  "logContextSuite",
 			"level":          "DEBUG",
 			"message":        "Debug message",
 			"some":           "thing",
 		},
 		{
 			"@timestamp":     differs.RFC3339NanoTime(),
-			"app.version":    "testing",
+			"app.version":    differs.AnyString(),
 			"context.string": "test",
 			"context.number": float64(5),
-			"context.suite":  "logContextSuite",
 			"level":          "ERROR",
 			"message":        "Warn message",
 			"some":           "thing",

--- a/pkg/log/log_context_test.go
+++ b/pkg/log/log_context_test.go
@@ -34,9 +34,7 @@ func (logContextSuite) TestLogContext(t *testing.T) {
 	defer logs.Close()
 
 	ctx := context.Background()
-	ctx = log.NewContext(ctx)
-	log.AllowContextFields("context.string", "context.number", "or.org.guid", "or.org.shortname")
-	log.AddInfo(ctx,
+	ctx = log.NewContext(ctx,
 		log.F{"context.string": "test",
 			"context": log.F{
 				"number": 5,
@@ -49,6 +47,85 @@ func (logContextSuite) TestLogContext(t *testing.T) {
 			"bento",
 		},
 		})
+
+	log.Debug(ctx, "Debug message", log.F{"some": "thing"})
+	log.Info(ctx, "Info message", log.F{"some": "thing"})
+	log.Warn(ctx, "Warn message", log.F{"some": "thing"})
+	log.Error(ctx, "Warn message", log.F{"some": "thing"})
+
+	expected := []log.F{
+		{
+			"@timestamp":       differs.RFC3339NanoTime(),
+			"app.version":      differs.AnyString(),
+			"context.string":   "test",
+			"context.number":   float64(5),
+			"level":            "INFO",
+			"message":          "Info message",
+			"or.org.guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
+			"or.org.shortname": "short",
+			"some":             "thing",
+		},
+		{
+			"@timestamp":       differs.RFC3339NanoTime(),
+			"app.version":      differs.AnyString(),
+			"context.string":   "test",
+			"context.number":   float64(5),
+			"level":            "WARN",
+			"message":          "Warn message",
+			"or.org.guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
+			"or.org.shortname": "short",
+			"some":             "thing",
+		},
+		{
+			"@timestamp":       differs.RFC3339NanoTime(),
+			"app.version":      differs.AnyString(),
+			"context.string":   "test",
+			"context.number":   float64(5),
+			"level":            "DEBUG",
+			"message":          "Debug message",
+			"or.org.guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
+			"or.org.shortname": "short",
+			"some":             "thing",
+		},
+		{
+			"@timestamp":       differs.RFC3339NanoTime(),
+			"app.version":      differs.AnyString(),
+			"context.string":   "test",
+			"context.number":   float64(5),
+			"level":            "ERROR",
+			"message":          "Warn message",
+			"or.org.guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
+			"or.org.shortname": "short",
+			"some":             "thing",
+		},
+	}
+
+	if diff := cmp.Diff(expected, logs.Entries(), differs.Custom()); diff != "" {
+		t.Fatal("unexpected log entries", diff)
+	}
+}
+
+func (logContextSuite) TestNestedLogContext(t *testing.T) {
+	logs := logtest.NewLogRecorder(t)
+	defer logs.Close()
+
+	ctx := context.Background()
+	ctx = log.NewContext(ctx,
+		log.F{"context.string": "test",
+			"context": log.F{
+				"number": 5,
+				"bar":    "not_allowed"},
+			"foo": "not_allowed",
+		})
+
+	ctx = log.NewContext(ctx,
+		log.F{"or.org": &orgInfo{
+			"bab20e22-834c-466c-a1df-90873b8b22a6",
+			"short",
+			"bento",
+		},
+		})
+
 	log.Debug(ctx, "Debug message", log.F{"some": "thing"})
 	log.Info(ctx, "Info message", log.F{"some": "thing"})
 	log.Warn(ctx, "Warn message", log.F{"some": "thing"})

--- a/pkg/log/log_context_test.go
+++ b/pkg/log/log_context_test.go
@@ -118,7 +118,7 @@ func (logContextSuite) TestNestedLogContext(t *testing.T) {
 			"foo": "not_allowed",
 		})
 
-	ctx = log.NewContext(ctx,
+	nestedCtx := log.NewContext(ctx,
 		log.F{"or.org": &orgInfo{
 			"bab20e22-834c-466c-a1df-90873b8b22a6",
 			"short",
@@ -126,6 +126,10 @@ func (logContextSuite) TestNestedLogContext(t *testing.T) {
 		},
 		})
 
+	log.Debug(nestedCtx, "Debug message", log.F{"some": "thing"})
+	log.Info(nestedCtx, "Info message", log.F{"some": "thing"})
+	log.Warn(nestedCtx, "Warn message", log.F{"some": "thing"})
+	log.Error(nestedCtx, "Warn message", log.F{"some": "thing"})
 	log.Debug(ctx, "Debug message", log.F{"some": "thing"})
 	log.Info(ctx, "Info message", log.F{"some": "thing"})
 	log.Warn(ctx, "Warn message", log.F{"some": "thing"})
@@ -175,6 +179,42 @@ func (logContextSuite) TestNestedLogContext(t *testing.T) {
 			"or.org.guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
 			"or.org.shortname": "short",
 			"some":             "thing",
+		},
+		{
+			"@timestamp":     differs.RFC3339NanoTime(),
+			"app.version":    differs.AnyString(),
+			"context.string": "test",
+			"context.number": float64(5),
+			"level":          "INFO",
+			"message":        "Info message",
+			"some":           "thing",
+		},
+		{
+			"@timestamp":     differs.RFC3339NanoTime(),
+			"app.version":    differs.AnyString(),
+			"context.string": "test",
+			"context.number": float64(5),
+			"level":          "WARN",
+			"message":        "Warn message",
+			"some":           "thing",
+		},
+		{
+			"@timestamp":     differs.RFC3339NanoTime(),
+			"app.version":    differs.AnyString(),
+			"context.string": "test",
+			"context.number": float64(5),
+			"level":          "DEBUG",
+			"message":        "Debug message",
+			"some":           "thing",
+		},
+		{
+			"@timestamp":     differs.RFC3339NanoTime(),
+			"app.version":    differs.AnyString(),
+			"context.string": "test",
+			"context.number": float64(5),
+			"level":          "ERROR",
+			"message":        "Warn message",
+			"some":           "thing",
 		},
 	}
 

--- a/pkg/log/log_context_test.go
+++ b/pkg/log/log_context_test.go
@@ -22,9 +22,19 @@ func (logContextSuite) TestLogContext(t *testing.T) {
 	defer logs.Close()
 
 	ctx := context.Background()
-	ctx = log.NewLogContext(ctx)
-	log.SetAllowedLogContextFields("context.string", "context.number")
-	log.AddInfo(ctx, log.F{"context.string": "test", "context.number": 5, "foo": "not_allowed"})
+	ctx = log.NewContext(ctx)
+	log.AllowContextFields("context.string", "context.number", "or.org.guid", "or.org.shortname")
+	log.AddInfo(ctx,
+		log.F{"context.string": "test",
+			"context": log.F{
+				"number": 5,
+				"bar":    "not_allowed"},
+			"or.org": log.F{
+				"guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
+				"shortname": "short",
+				"bento":     "bento",
+			},
+			"foo": "not_allowed"})
 	log.Debug(ctx, "Debug message", log.F{"some": "thing"})
 	log.Info(ctx, "Info message", log.F{"some": "thing"})
 	log.Warn(ctx, "Warn message", log.F{"some": "thing"})
@@ -32,40 +42,48 @@ func (logContextSuite) TestLogContext(t *testing.T) {
 
 	expected := []log.F{
 		{
-			"@timestamp":     differs.RFC3339NanoTime(),
-			"app.version":    differs.AnyString(),
-			"context.string": "test",
-			"context.number": float64(5),
-			"level":          "INFO",
-			"message":        "Info message",
-			"some":           "thing",
+			"@timestamp":       differs.RFC3339NanoTime(),
+			"app.version":      differs.AnyString(),
+			"context.string":   "test",
+			"context.number":   float64(5),
+			"level":            "INFO",
+			"message":          "Info message",
+			"or.org.guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
+			"or.org.shortname": "short",
+			"some":             "thing",
 		},
 		{
-			"@timestamp":     differs.RFC3339NanoTime(),
-			"app.version":    differs.AnyString(),
-			"context.string": "test",
-			"context.number": float64(5),
-			"level":          "WARN",
-			"message":        "Warn message",
-			"some":           "thing",
+			"@timestamp":       differs.RFC3339NanoTime(),
+			"app.version":      differs.AnyString(),
+			"context.string":   "test",
+			"context.number":   float64(5),
+			"level":            "WARN",
+			"message":          "Warn message",
+			"or.org.guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
+			"or.org.shortname": "short",
+			"some":             "thing",
 		},
 		{
-			"@timestamp":     differs.RFC3339NanoTime(),
-			"app.version":    differs.AnyString(),
-			"context.string": "test",
-			"context.number": float64(5),
-			"level":          "DEBUG",
-			"message":        "Debug message",
-			"some":           "thing",
+			"@timestamp":       differs.RFC3339NanoTime(),
+			"app.version":      differs.AnyString(),
+			"context.string":   "test",
+			"context.number":   float64(5),
+			"level":            "DEBUG",
+			"message":          "Debug message",
+			"or.org.guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
+			"or.org.shortname": "short",
+			"some":             "thing",
 		},
 		{
-			"@timestamp":     differs.RFC3339NanoTime(),
-			"app.version":    differs.AnyString(),
-			"context.string": "test",
-			"context.number": float64(5),
-			"level":          "ERROR",
-			"message":        "Warn message",
-			"some":           "thing",
+			"@timestamp":       differs.RFC3339NanoTime(),
+			"app.version":      differs.AnyString(),
+			"context.string":   "test",
+			"context.number":   float64(5),
+			"level":            "ERROR",
+			"message":          "Warn message",
+			"or.org.guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
+			"or.org.shortname": "short",
+			"some":             "thing",
 		},
 	}
 

--- a/pkg/log/log_context_test.go
+++ b/pkg/log/log_context_test.go
@@ -1,0 +1,78 @@
+package log_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/getoutreach/gobox/pkg/differs"
+	"github.com/getoutreach/gobox/pkg/log"
+	"github.com/getoutreach/gobox/pkg/log/logtest"
+)
+
+type logContextSuite struct{}
+
+func (logContextSuite) String() string {
+	return "logContextSuite"
+}
+
+func (logContextSuite) TestLogContext(t *testing.T) {
+	logs := logtest.NewLogRecorder(t)
+	defer logs.Close()
+
+	ctx := context.Background()
+	ctx = log.NewLogContext(ctx)
+	log.AddInfo(ctx, log.F{"context.string": "test", "context.number": 5, "context.suite": logContextSuite{}})
+	log.Debug(ctx, "Debug message", log.F{"some": "thing"})
+	log.Info(ctx, "Info message", log.F{"some": "thing"})
+	log.Warn(ctx, "Warn message", log.F{"some": "thing"})
+	log.Error(ctx, "Warn message", log.F{"some": "thing"})
+
+	expected := []log.F{
+		{
+			"@timestamp":     differs.RFC3339NanoTime(),
+			"app.version":    "testing",
+			"context.string": "test",
+			"context.number": float64(5),
+			"context.suite":  "logContextSuite",
+			"level":          "INFO",
+			"message":        "Info message",
+			"some":           "thing",
+		},
+		{
+			"@timestamp":     differs.RFC3339NanoTime(),
+			"app.version":    "testing",
+			"context.string": "test",
+			"context.number": float64(5),
+			"context.suite":  "logContextSuite",
+			"level":          "WARN",
+			"message":        "Warn message",
+			"some":           "thing",
+		},
+		{
+			"@timestamp":     differs.RFC3339NanoTime(),
+			"app.version":    "testing",
+			"context.string": "test",
+			"context.number": float64(5),
+			"context.suite":  "logContextSuite",
+			"level":          "DEBUG",
+			"message":        "Debug message",
+			"some":           "thing",
+		},
+		{
+			"@timestamp":     differs.RFC3339NanoTime(),
+			"app.version":    "testing",
+			"context.string": "test",
+			"context.number": float64(5),
+			"context.suite":  "logContextSuite",
+			"level":          "ERROR",
+			"message":        "Warn message",
+			"some":           "thing",
+		},
+	}
+
+	if diff := cmp.Diff(expected, logs.Entries(), differs.Custom()); diff != "" {
+		t.Fatal("unexpected log entries", diff)
+	}
+}

--- a/pkg/log/log_context_test.go
+++ b/pkg/log/log_context_test.go
@@ -17,6 +17,18 @@ func (logContextSuite) String() string {
 	return "logContextSuite"
 }
 
+type orgInfo struct {
+	guid      string
+	shortname string
+	bento     string
+}
+
+func (o *orgInfo) MarshalLog(addField func(key string, v interface{})) {
+	addField("guid", o.guid)
+	addField("shortname", o.shortname)
+	addField("bento", o.bento)
+}
+
 func (logContextSuite) TestLogContext(t *testing.T) {
 	logs := logtest.NewLogRecorder(t)
 	defer logs.Close()
@@ -29,12 +41,14 @@ func (logContextSuite) TestLogContext(t *testing.T) {
 			"context": log.F{
 				"number": 5,
 				"bar":    "not_allowed"},
-			"or.org": log.F{
-				"guid":      "bab20e22-834c-466c-a1df-90873b8b22a6",
-				"shortname": "short",
-				"bento":     "bento",
-			},
-			"foo": "not_allowed"})
+			"foo": "not_allowed",
+		},
+		log.F{"or.org": &orgInfo{
+			"bab20e22-834c-466c-a1df-90873b8b22a6",
+			"short",
+			"bento",
+		},
+		})
 	log.Debug(ctx, "Debug message", log.F{"some": "thing"})
 	log.Info(ctx, "Info message", log.F{"some": "thing"})
 	log.Warn(ctx, "Warn message", log.F{"some": "thing"})


### PR DESCRIPTION
Adds a new context to log to propagate core fields using the central library.  This is similar to `trace.AddInfo` but has some key differences:

- MarshalLog is invoked immediately instead of dynamically
- The results are constrained to a finite set of value types

This is intended to be used sparingly, but since this is external OSS, we cannot effectively limit what fields we can supply here.  Perhaps we could set the limit on the number of fields supported, like 5 for example?

This is separate from trace.AddInfo, because we might have values there we do not want to share with logging.   This would also preserve this being an opt in, if you are not interested in these fields, if you don't create a Log context the execution will be the same as before.

