### PR TITLE
fix: Stop update on context cancellation

### DIFF
--- a/pkg/updater/github.go
+++ b/pkg/updater/github.go
@@ -403,7 +403,7 @@ func (g *Github) getFileFromArchive(ctx context.Context, f *os.File, storageDir,
 
 // finds specified file in provided tar archive and returns io.Reader and its size for extraction progress
 func findTarFile(ctx context.Context, archive *tar.Reader, filename string) (io.Reader, int64, error) {
-	for ctx.Err() != nil {
+	for ctx.Err() == nil {
 		header, err := archive.Next()
 
 		if err == io.EOF {

--- a/pkg/updater/github_test.go
+++ b/pkg/updater/github_test.go
@@ -2,7 +2,9 @@ package updater
 
 import (
 	"context"
+	"fmt"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/google/go-github/v34/github"
@@ -45,14 +47,14 @@ func TestGithub_SelectAsset(t *testing.T) {
 				name: "localizer",
 				assets: []*github.ReleaseAsset{
 					{
-						ID:   github.Int64(28295890),
-						Name: github.String("localizer_1.0.0_linux_amd64.tar.gz"),
+						ID:   github.Int64(28295887),
+						Name: github.String(fmt.Sprintf("localizer_1.0.0_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)),
 					},
 				},
 			},
 			want: &github.ReleaseAsset{
-				ID:   github.Int64(28295890),
-				Name: github.String("localizer_1.0.0_linux_amd64.tar.gz"),
+				ID:   github.Int64(28295887),
+				Name: github.String(fmt.Sprintf("localizer_1.0.0_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)),
 			},
 		},
 	}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Updater ignored SIGINT before.


<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-557]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
After this, the download is cancelled, but extraction will still finish if it started. To prevent that we'd have to wrap the reader in something context aware.


<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-557]: https://outreach-io.atlassian.net/browse/DTSS-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ