### PR TITLE
feat(box): add new fields for multi-cluster/docker image registry support

### DIFF
--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -3,7 +3,9 @@
 // that outreach provides, aka "startup in a box"
 package box
 
-import "time"
+import (
+	"time"
+)
 
 // SnapshotLockChannel is used to determine the quality of
 // a given snapshot
@@ -17,15 +19,15 @@ const (
 	SnapshotLockChannelRC SnapshotLockChannel = "rc"
 
 	// Version is the current version of the box spec.
-	Version float32 = 1
+	Version float32 = 2
 )
 
 type DeveloperEnvironmentConfig struct {
 	// SnapshotConfig is the snapshot configuration for the devenv
-	SnapshotConfig *SnapshotConfig `yaml:"snapshots"`
+	SnapshotConfig SnapshotConfig `yaml:"snapshots"`
 
 	// VaultConfig denotes how to talk to Vault
-	VaultConfig *VaultConfig `yaml:"vault"`
+	VaultConfig VaultConfig `yaml:"vault"`
 
 	// ImagePullSecret is a path to credentials used to pull images with
 	// currently the only supported value is a vault key path with
@@ -38,7 +40,7 @@ type DeveloperEnvironmentConfig struct {
 
 	// RuntimeConfig stores configuration specific to different devenv
 	// runtimes.
-	RuntimeConfig *DeveloperEnvironmentRuntimeConfig `yaml:"runtimeConfig"`
+	RuntimeConfig DeveloperEnvironmentRuntimeConfig `yaml:"runtimeConfig"`
 }
 
 // DeveloperEnvironmentRuntimeConfig stores configuration specific to
@@ -47,14 +49,12 @@ type DeveloperEnvironmentRuntimeConfig struct {
 	// EnabledRuntimes dictates which runtimes are enabled, generally defaults to all.
 	EnabledRuntimes []string `yaml:"enabledRuntimes"`
 
-	// Loft is configuration for the loft runtime in the devenv
-	Loft *LoftRuntimeConfig `yaml:"loft"`
-}
+	// DevelopmentRegistries are image registries that should be used for
+	// development docker images. These are only ever used for remote devenvs.
+	DevelopmentRegistries DevelopmentRegistries `yaml:"developmentRegistries"`
 
-// LoftRuntimeConfig is configuration for loft runtimes
-type LoftRuntimeConfig struct {
-	// URL is the URL of a loft instance.
-	URL string `yaml:"URL"`
+	// Loft is configuration for the loft runtime in the devenv
+	Loft LoftRuntimeConfig `yaml:"loft"`
 }
 
 // VaultConfig is the configuration for accessing Vault
@@ -100,7 +100,7 @@ type Config struct {
 	Org string `yaml:"org"`
 
 	// DeveloperEnvironmentConfig is the configuration for the developer environment for this box
-	DeveloperEnvironmentConfig *DeveloperEnvironmentConfig `yaml:"devenv"`
+	DeveloperEnvironmentConfig DeveloperEnvironmentConfig `yaml:"devenv"`
 }
 
 // Storage is a wrapper type used for storing the box configuration
@@ -120,11 +120,7 @@ type Storage struct {
 
 // NewConfig makes a full initialized Config
 func NewConfig() *Config {
-	return &Config{
-		DeveloperEnvironmentConfig: &DeveloperEnvironmentConfig{
-			SnapshotConfig: &SnapshotConfig{},
-		},
-	}
+	return &Config{}
 }
 
 // SnapshotTarget is the defn for a generated snapshot

--- a/pkg/box/development_registries.go
+++ b/pkg/box/development_registries.go
@@ -1,0 +1,38 @@
+// Copyright 2021 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains development registry configuration
+package box
+
+import "github.com/getoutreach/gobox/pkg/region"
+
+// DevelopmentRegistries contains a slice of DevelopmentRegistrys
+type DevelopmentRegistries struct {
+	// Path is a go-template string of the path to append to the end of the endpoint
+	// for the docker image registry to use. This is useful for namespacing images.
+	Path string `yaml:"path"`
+
+	// Clouds is a CloudName -> DevelopmentRegistriesSlice
+	Clouds map[region.CloudName]DevelopmentRegistriesSlice
+}
+
+// DevelopmentRegistriesSlice is a slice of DevelopmentRegistry
+type DevelopmentRegistriesSlice []DevelopmentRegistry
+
+// Regions returns all of the regions of the development registries
+func (dr DevelopmentRegistriesSlice) Regions() []region.Name {
+	regions := make([]region.Name, 0)
+	for _, e := range dr {
+		regions = append(regions, e.Region)
+	}
+	return regions
+}
+
+// DevelopmentRegistry is a docker image registry used for development
+type DevelopmentRegistry struct {
+	// Endpoint is the endpoint of this registry, e.g.
+	// gcr.io/outreach-docker or docker.io/getoutreach
+	Endpoint string `yaml:"endpoint"`
+
+	// Region that this registry should be used in. If not set will be randomly selected.
+	Region region.Name `yaml:"region"`
+}

--- a/pkg/box/loft.go
+++ b/pkg/box/loft.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains box configuration for loft
+package box
+
+import "github.com/getoutreach/gobox/pkg/region"
+
+// LoftRuntimeConfig is configuration for loft runtimes
+type LoftRuntimeConfig struct {
+	// Clusters is a list of clusters provided by this loft instance
+	Clusters LoftClusters `yaml:"clusters"`
+
+	// DefaultCloud is the default cloud to use. Currently the only way to specify
+	// which cloud.
+	DefaultCloud region.CloudName `yaml:"defaultCloud"`
+
+	// DefaultRegion is the default region to use when a nearest one couldn't
+	// be calculated
+	DefaultRegion region.Name `yaml:"regionName"`
+
+	// URL is the URL of a loft instance.
+	URL string `yaml:"URL"`
+}
+
+// LoftCluster is a loft cluster
+type LoftCluster struct {
+	// Name is the name of the cluster in loft
+	Name string `yaml:"name"`
+
+	// Region is the region that this cluster is in
+	Region region.Name `yaml:"region"`
+
+	// Cloud is the cloud that this loft cluster is in. Not currently used anywhere.
+	Cloud region.CloudName `yaml:"cloud"`
+}
+
+// LoftClusters is a container for a slice of LoftClusters
+type LoftClusters []LoftCluster
+
+// Regions returns all of the regions of the regions for the loft clusters in a []LoftCluster
+func (lc LoftClusters) Regions() []region.Name {
+	regions := make([]region.Name, 0)
+	for _, e := range lc {
+		regions = append(regions, e.Region)
+	}
+	return regions
+}

--- a/pkg/region/cache.go
+++ b/pkg/region/cache.go
@@ -119,6 +119,10 @@ func (c *cacheStore) getCacheFilePath() (string, error) {
 		storageDir = filepath.Join(homeDir, storageDir)
 	}
 
+	// ensure that the directory exists
+	//nolint:errcheck // Why: best effort
+	os.MkdirAll(storageDir, 0755)
+
 	return filepath.Join(storageDir, RegionCacheFile), nil
 }
 

--- a/pkg/region/cache.go
+++ b/pkg/region/cache.go
@@ -52,7 +52,7 @@ func (c *cacheStore) expireKeyIfRequired(cloud CloudName, r Name, v *cacheEntry)
 		c.mu.Unlock()
 
 		// save the expiration to disk
-		c.save()
+		c.save() //nolint:errcheck // Why: best effort
 		return true
 	}
 

--- a/pkg/region/cache.go
+++ b/pkg/region/cache.go
@@ -45,13 +45,18 @@ type cacheStore struct {
 }
 
 // expireKeyIfRequired expires a key if it's ready to be expired
-func (c *cacheStore) expireKeyIfRequired(cloud CloudName, r Name, v *cacheEntry) {
+func (c *cacheStore) expireKeyIfRequired(cloud CloudName, r Name, v *cacheEntry) bool {
 	if time.Now().UTC().After(v.ExpiresAt) {
 		c.mu.Lock()
-		defer c.mu.Unlock()
-
 		delete(c.Clouds[cloud], r)
+		c.mu.Unlock()
+
+		// save the expiration to disk
+		c.save()
+		return true
 	}
+
+	return false
 }
 
 // get returns a cache entry for a given cloud/region pairing
@@ -78,7 +83,10 @@ func (c *cacheStore) Get(cloud CloudName, r Name) (time.Duration, bool) {
 		return time.Duration(0), false
 	}
 
-	c.expireKeyIfRequired(cloud, r, v) // expire the key if required to do so
+	// expire the key if required to do so
+	if c.expireKeyIfRequired(cloud, r, v) {
+		return time.Duration(0), false
+	}
 
 	return v.Duration, ok
 }

--- a/pkg/region/cloud.go
+++ b/pkg/region/cloud.go
@@ -12,3 +12,15 @@ type CloudName string
 type Cloud interface {
 	Regions(ctx context.Context) Regions
 }
+
+// supportedClouds is a CloudName -> Cloud mapping
+// of all known/supported clouds
+var supportedClouds = map[CloudName]Cloud{
+	CloudGCP:    &GCP{},
+	CloudCustom: &CustomCloud{},
+}
+
+// CloudFromCloudName returns a cloud from a provided cloud name
+func CloudFromCloudName(cloud CloudName) Cloud {
+	return supportedClouds[cloud]
+}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds support to `box` for expressing development docker image registries as well as for listing available clusters for loft. This will be used by the devenv for both `tilt` integration as well as with `loft` for picking and choosing which cluster to use for backing a cloud devenv. This is contingent on me getting direct cluster endpoints to also work, but that's digressing.


<!--- Block(jiraPrefix) --->
**JIRA ID**: [XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
