### PR TITLE
fix: Use not-authenticated http client for downloading updates

### DIFF
--- a/pkg/updater/github.go
+++ b/pkg/updater/github.go
@@ -252,12 +252,15 @@ func (g *Github) DownloadRelease(ctx context.Context, r *github.RepositoryReleas
 		return "", func() {}, err
 	}
 
-	req, err := g.gc.NewRequest(http.MethodGet, url, nil)
+	// The url returned from SelectAsset has auth in it.
+	// That endpoint doesn't allow double auth, and so we don't send the bearer token.
+	// Instead, we use the default http client with no auth on every request.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", func() {}, errors.Wrapf(err, "failed to create HTTP request to '%s'", url)
 	}
 
-	resp, err := g.gc.BareDo(ctx, req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", func() {}, errors.Wrapf(err, "failed to send HTTP request to '%s'", url)
 	}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
The URL you can see on release pages on GitHub redirects to an already authenticated URL (has auth as query params).

This endpoint doesn't allow double auth, and the github client's http client automatically adds Bearer auth header.

Using default http client, we avoid this issue.


<!--- Block(jiraPrefix) --->
**JIRA ID**: [XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
You can see the issue being fixed here on  bootstrapbot check.


<!--- Block(custom) -->
<!--- EndBlock(custom) -->
