### PR TITLE
fix: Refactor pkg/trace and pkg/log a bit by pulling out some helpers into internal/

### DIFF
--- a/internal/call/call.go
+++ b/internal/call/call.go
@@ -1,0 +1,119 @@
+// The call package helps support tracking latency and other metrics for calls.
+package call
+
+import (
+	"context"
+	"time"
+
+	"github.com/getoutreach/gobox/internal/logf"
+	"github.com/getoutreach/gobox/pkg/app"
+	"github.com/getoutreach/gobox/pkg/events"
+	"github.com/getoutreach/gobox/pkg/metrics"
+)
+
+// Type tracks the call type.
+type Type string
+
+const (
+	// TypeHTTP is a constant that denotes the call type being an HTTP
+	// request.
+	TypeHTTP Type = "http"
+
+	// TypeGRPC is a constant that denotes the call type being a gRPC
+	// request.
+	TypeGRPC Type = "grpc"
+
+	// TypeOutbound is a constant that denotes the call type being an
+	// outbound request.
+	TypeOutbound Type = "outbound"
+)
+
+// Info tracks information about an ongoing synchronous call.
+type Info struct {
+	Name string
+	Type Type
+	Kind metrics.CallKind
+	Args []logf.Marshaler
+
+	events.Times
+	events.Durations
+
+	ErrInfo *events.ErrorInfo
+}
+
+func (info *Info) Start(ctx context.Context, name string) {
+	info.Name = name
+	if info.Kind == "" {
+		info.Kind = metrics.CallKindInternal
+	}
+	info.Times.Started = time.Now()
+}
+
+func (info *Info) End(ctx context.Context) {
+	info.Times.Finished = time.Now()
+	info.Durations = *info.Times.Durations()
+}
+
+func (info *Info) ReportLatency(ctx context.Context) {
+	var err error
+	if info.ErrInfo != nil {
+		err = info.ErrInfo.RawError
+	}
+
+	name, kind := app.Info().Name, metrics.WithCallKind(info.Kind)
+	switch info.Type {
+	case TypeHTTP:
+		metrics.ReportHTTPLatency(name, info.Name, info.ServiceSeconds, err, kind)
+	case TypeGRPC:
+		metrics.ReportGRPCLatency(name, info.Name, info.ServiceSeconds, err, kind)
+	case TypeOutbound:
+		metrics.ReportOutboundLatency(name, info.Name, info.ServiceSeconds, err, kind)
+	default:
+		// do not report anything.
+	}
+}
+
+func (info *Info) AddArgs(ctx context.Context, args ...logf.Marshaler) {
+	info.Args = append(info.Args, args...)
+}
+
+func (info *Info) SetStatus(ctx context.Context, err error) {
+	info.ErrInfo = events.NewErrorInfo(err)
+}
+
+func (info *Info) MarshalLog(addField func(key string, value interface{})) {
+	info.Times.MarshalLog(addField)
+	info.Durations.MarshalLog(addField)
+	logf.Many(info.Args).MarshalLog(addField)
+	info.ErrInfo.MarshalLog(addField)
+}
+
+// Tracker helps manage a call info via the context.
+type Tracker struct {
+}
+
+func (t *Tracker) StartCall(ctx context.Context, name string, args []logf.Marshaler) context.Context {
+	var info Info
+	info.Start(ctx, name)
+	info.AddArgs(ctx, args...)
+	return context.WithValue(ctx, t, &info)
+}
+
+func (t *Tracker) Info(ctx context.Context) *Info {
+	if v := ctx.Value(t); v != nil {
+		return v.(*Info)
+	}
+	return nil
+}
+
+func (t *Tracker) EndCall(ctx context.Context) {
+	info := t.Info(ctx)
+	if r := recover(); r != nil {
+		info.ErrInfo = events.NewErrorInfoFromPanic(r)
+
+		// rethrow at end of the function
+		defer panic(r)
+	}
+
+	info.End(ctx)
+}

--- a/internal/call/call_test.go
+++ b/internal/call/call_test.go
@@ -1,0 +1,173 @@
+package call_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/getoutreach/gobox/internal/call"
+	"github.com/getoutreach/gobox/internal/logf"
+	"github.com/getoutreach/gobox/pkg/differs"
+	"github.com/prometheus/client_golang/prometheus"
+	"gotest.tools/v3/assert"
+)
+
+func TestTracker_nestedCall(t *testing.T) {
+	tracker := &call.Tracker{}
+	ctx := context.Background()
+
+	outer := tracker.StartCall(ctx, "outer", logf.Many{logf.F{"outer": true}})
+	outerInfo := tracker.Info(outer)
+
+	if assert.Check(t, outerInfo != nil) {
+		assert.Assert(t, !outerInfo.Times.Started.IsZero())
+		assert.Equal(t, outerInfo.Name, "outer")
+	}
+
+	inner := tracker.StartCall(outer, "inner", logf.Many{logf.F{"inner": true}})
+	innerInfo := tracker.Info(inner)
+
+	if assert.Check(t, innerInfo != nil) {
+		assert.Assert(t, innerInfo != outerInfo)
+		assert.Assert(t, !innerInfo.Times.Started.IsZero())
+		assert.Equal(t, innerInfo.Name, "inner")
+	}
+
+	time.Sleep(time.Millisecond * 5)
+
+	tracker.EndCall(inner)
+	tracker.EndCall(outer)
+
+	assert.Assert(t, tracker.Info(ctx) == nil)
+
+	assert.DeepEqual(t, marshalInfo(innerInfo), logf.F{
+		"inner":               true,
+		"timing.dequeued_at":  differs.RFC3339NanoTime(),
+		"timing.finished_at":  differs.RFC3339NanoTime(),
+		"timing.scheduled_at": differs.RFC3339NanoTime(),
+		"timing.service_time": differs.FloatRange(0, 0.1),
+		"timing.total_time":   differs.FloatRange(0, 0.1),
+		"timing.wait_time":    differs.FloatRange(0, 0.001),
+	}, differs.Custom())
+
+	assert.DeepEqual(t, marshalInfo(outerInfo), logf.F{
+		"outer":               true,
+		"timing.dequeued_at":  differs.RFC3339NanoTime(),
+		"timing.finished_at":  differs.RFC3339NanoTime(),
+		"timing.scheduled_at": differs.RFC3339NanoTime(),
+		"timing.service_time": differs.FloatRange(0, 0.1),
+		"timing.total_time":   differs.FloatRange(0, 0.1),
+		"timing.wait_time":    differs.FloatRange(0, 0.001),
+	}, differs.Custom())
+}
+
+func TestTracker_panic(t *testing.T) {
+	tracker := &call.Tracker{}
+	ctx := context.Background()
+
+	outer := tracker.StartCall(ctx, "outer", logf.Many{logf.F{"outer": true}})
+	outerInfo := tracker.Info(outer)
+
+	defer func() {
+		// The main validation happens within the panic.
+		r := recover()
+		assert.Equal(t, r, "testing panic")
+
+		assert.DeepEqual(t, marshalInfo(outerInfo), logf.F{
+			"error.error":         "testing panic",
+			"error.kind":          "panic",
+			"error.message":       "testing panic",
+			"error.stack":         differs.AnyString(),
+			"outer":               true,
+			"timing.dequeued_at":  differs.RFC3339NanoTime(),
+			"timing.finished_at":  differs.RFC3339NanoTime(),
+			"timing.scheduled_at": differs.RFC3339NanoTime(),
+			"timing.service_time": differs.FloatRange(0, 0.1),
+			"timing.total_time":   differs.FloatRange(0, 0.1),
+			"timing.wait_time":    differs.FloatRange(0, 0.001),
+		}, differs.Custom())
+	}()
+
+	defer tracker.EndCall(outer)
+	panic("testing panic")
+}
+
+func TestTracker_reportLatency(t *testing.T) {
+	tracker := &call.Tracker{}
+	ctx := context.Background()
+
+	types := []call.Type{call.TypeHTTP, call.TypeGRPC, call.TypeOutbound}
+	statuses := []string{"ok", "failed"}
+
+	for _, callType := range types {
+		for _, status := range statuses {
+			name := string(callType) + "-" + status
+			outer := tracker.StartCall(ctx, name, nil)
+			outerInfo := tracker.Info(outer)
+			outerInfo.Type = callType
+			if status != "ok" {
+				outerInfo.SetStatus(outer, errors.New(status))
+				assert.Assert(t, outerInfo.ErrInfo.RawError != nil)
+			}
+			tracker.EndCall(outer)
+			outerInfo.ReportLatency(ctx)
+		}
+	}
+
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	assert.NilError(t, err)
+
+	callFamily := map[call.Type]string{
+		call.TypeHTTP:     "http_request_handled",
+		call.TypeGRPC:     "grpc_request_handled",
+		call.TypeOutbound: "outbound_call_seconds",
+	}
+
+	for _, callType := range types {
+		for _, status := range statuses {
+			name := string(callType) + "-" + status
+			family := callFamily[callType]
+
+			need := map[string]string{
+				"call":           name,
+				"kind":           "internal",
+				"statuscategory": "CategoryOK",
+				"statuscode":     "OK",
+			}
+			if status != "ok" {
+				need["statuscategory"] = "CategoryServerError"
+				need["statuscode"] = "UnknownError"
+			}
+
+			got := map[string]string{}
+
+			for _, metricFamily := range metrics {
+				if metricFamily.GetName() != family {
+					continue
+				}
+				for _, metric := range metricFamily.Metric {
+					got = map[string]string{}
+					for _, labelPair := range metric.GetLabel() {
+						key, value := labelPair.GetName(), labelPair.GetValue()
+						if _, ok := need[key]; ok {
+							got[key] = value
+						}
+					}
+
+					if got["call"] == name {
+						break
+					}
+				}
+			}
+
+			assert.DeepEqual(t, need, got)
+		}
+	}
+}
+
+func marshalInfo(info *call.Info) logf.F {
+	result := logf.F{}
+	result.Set("", info)
+	return result
+}

--- a/internal/logf/logf.go
+++ b/internal/logf/logf.go
@@ -1,0 +1,68 @@
+// package logf has the log.F implementation
+package logf
+
+import "strings"
+
+// Marshaler is the same interface as log.Marshaler.
+type Marshaler interface {
+	MarshalLog(addField func(key string, v interface{}))
+}
+
+// Marshal is a helper that checks if the interface provided
+// implements Marshaler.  If it does, it recursively calls MarshalLog
+// building up the prefixes long (combining them with ".").
+func Marshal(prefix string, v interface{}, setField func(key string, value interface{})) {
+	if rm, ok := v.(interface{ MarshalRoot() Marshaler }); ok {
+		Marshal("", rm.MarshalRoot(), setField)
+	}
+
+	if m, ok := v.(Marshaler); ok {
+		m.MarshalLog(func(inner string, val interface{}) {
+			if prefix == "" {
+				Marshal(inner, val, setField)
+			} else {
+				Marshal(prefix+"."+inner, val, setField)
+			}
+		})
+	} else {
+		setField(prefix, v)
+	}
+}
+
+// F implements a generic log.Marshaler interface
+type F map[string]interface{}
+
+// Set writes the field value into F. If the value implements
+// interface { MarshalRoot() log.Marshaler } then it marshals it
+// from the root level. If the value is a
+// log.Marshaler, it recursively marshals that value into F.
+func (f F) Set(field string, value interface{}) {
+	Marshal(field, value, func(key string, value interface{}) {
+		if f["level"] == "FATAL" && strings.HasPrefix(key, "error.") {
+			// if this is a FATAL, make room for the root call stack
+			key = "error.cause." + key[6:]
+		}
+		f[key] = value
+	})
+}
+
+// MarshalLog implements the Marshaler interface for F
+func (f F) MarshalLog(addField func(field string, value interface{})) {
+	for k, v := range f {
+		addField(k, v)
+	}
+}
+
+// Many aggregates marshaling of many items
+//
+// This avoids having to build an append list and also simplifies code
+type Many []Marshaler
+
+// MarshalLog calls MarshalLog on all the individual elements
+func (m Many) MarshalLog(addField func(key string, v interface{})) {
+	for _, item := range m {
+		if item != nil {
+			item.MarshalLog(addField)
+		}
+	}
+}

--- a/internal/logf/logf.go
+++ b/internal/logf/logf.go
@@ -1,3 +1,7 @@
+// Copyright 2021 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains the helper utilities for marshaling log fields.
+
 // package logf has the log.F implementation
 package logf
 

--- a/pkg/log/many.go
+++ b/pkg/log/many.go
@@ -1,15 +1,8 @@
 package log
 
+import "github.com/getoutreach/gobox/internal/logf"
+
 // Many aggregates marshaling of many items
 //
 // This avoids having to build an append list and also simplifies code
-type Many []Marshaler
-
-// MarshalLog calls MarshalLog on all the individual elements
-func (m Many) MarshalLog(addField func(key string, v interface{})) {
-	for _, item := range m {
-		if item != nil {
-			item.MarshalLog(addField)
-		}
-	}
-}
+type Many = logf.Many

--- a/pkg/trace/call.go
+++ b/pkg/trace/call.go
@@ -11,7 +11,7 @@ import (
 	"github.com/getoutreach/gobox/pkg/statuscodes"
 )
 
-// nolint:nochecknoglobals Why: we use this as a singleton.
+// nolint:nochecknoglobals // Why: we use this as a singleton.
 var callTracker = &call.Tracker{}
 
 // StartCall is used to start an internal call. For external calls please

--- a/pkg/trace/call.go
+++ b/pkg/trace/call.go
@@ -11,7 +11,7 @@ import (
 	"github.com/getoutreach/gobox/pkg/statuscodes"
 )
 
-// nolint:nochecknoglobals
+// nolint:nochecknoglobals Why: we use this as a singleton.
 var callTracker = &call.Tracker{}
 
 // StartCall is used to start an internal call. For external calls please


### PR DESCRIPTION
## What this PR does / why we need it
This refactors the trace package which has gotten really unwieldy.
**JIRA ID**: [XX-XX]

There is no functional change.  Just pulling out some functionality into internal packages. 

I pulled out the recursive marshaling functionality into logf (as well as log.F and log.Many) allowing us to share this between trace and log.
I pulled out the core call tracking functionality into `call`.  

I had more changes but the PR was getting larger, so I decided to shave this off by itself first. 