### PR TITLE
feat(logtest): register recorder closing on tests cleanup

### DIFF
--- a/pkg/log/logtest/logtest.go
+++ b/pkg/log/logtest/logtest.go
@@ -4,7 +4,6 @@
 //
 //     func MyTestFunc(t *testing.T) {
 //         logs := logTest.NewLogRecorder(t)
-//         defer logs.Close()
 //         .....
 //         if diff := logs.Diff(expected); diff != "" {
 //             t.Fatal("logs unexpected", diff);
@@ -23,10 +22,16 @@ import (
 
 // NewLogRecorder starts a new log recorder.
 //
-// Logs must be stopped by calling Close() on the recorder
+// No need to call Close() explicitly, it will be called for you when the tests are completed.
 func NewLogRecorder(t *testing.T) *LogRecorder {
 	r := &LogRecorder{T: t, oldOutput: log.Output()}
 	log.SetOutput(r)
+	if t != nil {
+		t.Cleanup(func() {
+			r.Close()
+		})
+	}
+
 	return r
 }
 

--- a/pkg/log/logtest/logtest.go
+++ b/pkg/log/logtest/logtest.go
@@ -1,4 +1,4 @@
-// logtest provides the ability to test logs
+// Package logtest provides the ability to test logs
 //
 // Usage:
 //
@@ -62,7 +62,7 @@ func (l *LogRecorder) Entries() []log.F {
 	return l.entries[:len(l.entries):len(l.entries)]
 }
 
-// MarshalToMap uses the given arguments `MarshalLog` function to serialize it
+// Map uses the given arguments `MarshalLog` function to serialize it
 // into a map, which it returns.
 //
 // The serialization is similar to the one performed by logs.  Any nesting is


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Register logtest's `LogRecorder.Close()` as `t.Cleanup` function, so there is no need to close recorder manually.


<!--- Block(jiraPrefix) --->
**JIRA ID**: [XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
