### PR TITLE
feat: Adding in closer() and rungroups to async

### DIFF
--- a/pkg/async/async.go
+++ b/pkg/async/async.go
@@ -136,8 +136,6 @@ func RunClose(ctx context.Context, r Runner) error {
 func RunGroup(rg []Runner) Runner {
 	ru := Func(func(ctx context.Context) error {
 		g, ctx := errgroup.WithContext(ctx)
-		ctx, cancelFunc := context.WithCancel(ctx)
-		defer cancelFunc()
 		for idx := range rg {
 			r := rg[idx]
 			g.Go(func() error {
@@ -147,11 +145,7 @@ func RunGroup(rg []Runner) Runner {
 					}
 				}()
 
-				err := r.Run(ctx)
-				if err != nil {
-					cancelFunc()
-				}
-				return err
+				return r.Run(ctx)
 			})
 		}
 		return g.Wait()

--- a/pkg/async/async.go
+++ b/pkg/async/async.go
@@ -136,6 +136,8 @@ func RunClose(ctx context.Context, r Runner) error {
 func RunGroup(rg []Runner) Runner {
 	ru := Func(func(ctx context.Context) error {
 		g, ctx := errgroup.WithContext(ctx)
+		ctx, cancelFunc := context.WithCancel(ctx)
+		defer cancelFunc()
 		for idx := range rg {
 			r := rg[idx]
 			g.Go(func() error {
@@ -147,7 +149,7 @@ func RunGroup(rg []Runner) Runner {
 
 				err := r.Run(ctx)
 				if err != nil {
-					<-ctx.Done()
+					cancelFunc()
 				}
 				return err
 			})

--- a/pkg/async/async_test.go
+++ b/pkg/async/async_test.go
@@ -26,6 +26,7 @@ type runWithCloser struct {
 
 func (r *runWithCloser) Run(c context.Context) error {
 	for {
+		time.Sleep(time.Second)
 		if c.Err() != nil {
 			return c.Err()
 		}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
Adds async functions for running a group of tasks and for closing out tasks.
<!--- Block(jiraPrefix) --->

## Jira ID

[QSS-836]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[QSS-836]: https://outreach-io.atlassian.net/browse/QSS-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ