### PR TITLE
fix: properly unmarshal box config

### DIFF
--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -127,7 +127,7 @@ type Storage struct {
 	// Config is the box configuration, see Config.
 	// This is an yaml.Node because we can't guarantee that the
 	// underlying type is a Config as we expect it to be.
-	Config *yaml.Node `yaml:"config"`
+	Config yaml.Node `yaml:"config"`
 
 	// LastUpdated is the last time this file was checked for updates
 	LastUpdated time.Time `yaml:"lastUpdated"`

--- a/pkg/box/fetch.go
+++ b/pkg/box/fetch.go
@@ -161,13 +161,13 @@ func EnsureBoxWithOptions(ctx context.Context, optFns ...LoadBoxOption) (*Config
 
 // downloadBox downloads and parses a box config from a given repository
 // URL.
-func downloadBox(ctx context.Context, gitRepo string) (*yaml.Node, error) {
+func downloadBox(ctx context.Context, gitRepo string) (yaml.Node, error) {
 	a := sshhelper.GetSSHAgent()
 
 	//nolint:errcheck // Why: Best effort and not worth bringing logger here
 	_, err := sshhelper.LoadDefaultKey("github.com", a, &logrus.Logger{Out: io.Discard})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to load Github SSH key into in-memory keyring")
+		return yaml.Node{}, errors.Wrap(err, "failed to load Github SSH key into in-memory keyring")
 	}
 
 	fs := memfs.New()
@@ -177,22 +177,22 @@ func downloadBox(ctx context.Context, gitRepo string) (*yaml.Node, error) {
 		Depth: 1,
 	})
 	if err != nil {
-		return nil, err
+		return yaml.Node{}, err
 	}
 
 	f, err := fs.Open(BoxConfigFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read box configuration file")
+		return yaml.Node{}, errors.Wrap(err, "failed to read box configuration file")
 	}
 
 	// Parse the config into a yaml.Node to keep comments
 	var n yaml.Node
 	if err := yaml.NewDecoder(f).Decode(&n); err != nil {
-		return nil, errors.Wrap(err, "failed to decode box configuration file")
+		return yaml.Node{}, errors.Wrap(err, "failed to decode box configuration file")
 	}
 
 	// We return the first node because we don't want the document start
-	return n.Content[0], nil
+	return *n.Content[0], nil
 }
 
 // SaveBox takes a Storage wrapped box configuration, serializes it


### PR DESCRIPTION
**What this PR does**: Somehow `*yaml.Node` fails to unmarshal (silently) but `yaml.Node` doesn't. Noice. Cool. Dope.