### PR TITLE
fix: support CI address for vault

### DIFF
--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -80,6 +80,10 @@ type VaultConfig struct {
 
 	// Address is the URL to talk to Vault
 	Address string `yaml:"address"`
+
+	// AddressCI is the URL to use to talk to Vault in CI
+	// Defaults to Address
+	AddressCI string `yaml:"addressCI"`
 }
 
 // SnapshotConfig stores configuration for generated and accessing

--- a/pkg/box/fetch.go
+++ b/pkg/box/fetch.go
@@ -57,6 +57,11 @@ func ApplyEnvOverrides(s *Config) {
 	if role := os.Getenv("AWS_ROLE"); role != "" {
 		s.AWS.DefaultRole = role
 	}
+
+	// Set the CI address to the address if not set
+	if s.DeveloperEnvironmentConfig.VaultConfig.AddressCI == "" {
+		s.DeveloperEnvironmentConfig.VaultConfig.AddressCI = s.DeveloperEnvironmentConfig.VaultConfig.Address
+	}
 }
 
 // LoadBoxStorage reads a serialized, storage wrapped


### PR DESCRIPTION
**What this PR does**: We've had this `addressCI` in our box config for ever, but never exposed it. Now we do. 🎉 