### PR TITLE
fix: re-read box config after updating

### DIFF
--- a/pkg/box/fetch.go
+++ b/pkg/box/fetch.go
@@ -161,7 +161,13 @@ func EnsureBoxWithOptions(ctx context.Context, optFns ...LoadBoxOption) (*Config
 	if err != nil {
 		return nil, err
 	}
-	return c, SaveBox(ctx, s)
+	if err := SaveBox(ctx, s); err != nil {
+		return nil, err
+	}
+
+	// Reload the box config
+	s, c, err = LoadBoxStorage()
+	return c, err
 }
 
 // downloadBox downloads and parses a box config from a given repository


### PR DESCRIPTION
re-read box config after updating