### PR TITLE
fix: check for nil value

### DIFF
--- a/pkg/trace/call.go
+++ b/pkg/trace/call.go
@@ -80,7 +80,10 @@ func SetCallTypeOutbound(ctx context.Context) context.Context {
 // When the error is nil, no-op from this function
 func SetCallStatus(ctx context.Context, err error) error {
 	if err != nil {
-		callTracker.Info(ctx).SetStatus(ctx, err)
+		info := callTracker.Info(ctx)
+		if info != nil {
+			info.SetStatus(ctx, err)
+		}
 	}
 	return err
 }

--- a/pkg/trace/call_test.go
+++ b/pkg/trace/call_test.go
@@ -356,3 +356,7 @@ func (suite) TestEndCallDoesNotPanicWithNilError(t *testing.T) {
 	ctx := trace.StartCall(context.Background(), "")
 	trace.EndCall(ctx)
 }
+
+func (suite) TestSetCallStatusDoesNotPanicWithNilInfo(t *testing.T) {
+	trace.SetCallStatus(context.Background(), errors.New(""))
+}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

`trace.StartCall` is not guaranteed to be called for every request (e.g. for [Throttler requests](https://github.com/getoutreach/services/blob/main/pkg/grpcx/server.go#L177). 
If then `trace.SetCallError` or `trace.SetCallStatus` is called with an error, panic occurs.

<!--- Block(jiraPrefix) --->

## Jira ID

[RMS-764]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
