### PR TITLE
fix: corrected path of honeycomb key for cli app

### DIFF
--- a/pkg/cli/bootstrap.go
+++ b/pkg/cli/bootstrap.go
@@ -65,7 +65,7 @@ func overrideConfigLoaders(honeycombAPIKey, dataset string, tracingDebug bool) {
 					Enabled:  true,
 					Endpoint: "api.honeycomb.io",
 					APIKey: cfg.Secret{
-						Path: "APIKey",
+						Path: "apiKey",
 					},
 					Debug:         tracingDebug,
 					Dataset:       dataset,


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
```
2022/07/21 11:12:59 failed to send traces to https://api.honeycomb.io/v1/traces: 401 Unauthorized
```

The CLI app config token is overwritten here https://github.com/getoutreach/gobox/blob/6485f2071a631e50b90564ade7d848e63d5cf448/pkg/cli/bootstrap.go#L177


<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
