### PR TITLE
fix: update command referenced in enable-prereleases deprecation message

### DIFF
--- a/pkg/updater/cli.go
+++ b/pkg/updater/cli.go
@@ -49,7 +49,7 @@ func (u *updater) hookIntoCLI() {
 		for _, f := range c.FlagNames() {
 			if strings.EqualFold(f, "enable-prereleases") {
 				u.prereleases = true
-				u.log.Warn("--enable-prereleases is deprecated, use the new 'updater set-channel prereleases' command instead")
+				u.log.Warn("--enable-prereleases is deprecated, use the new 'updater set-channel rc' command instead")
 			}
 
 			if strings.EqualFold(f, "force-update-check") {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Updates the command referenced when saying the `--enable-prereleases` flag is deprecated from `updater set-channel prereleases` (which does not work) to `updater set-channel rc`

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2310]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2310]: https://outreach-io.atlassian.net/browse/DT-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ