### PR TITLE
feat: add lock to guard stdOut

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -42,9 +42,9 @@ var (
 	// wrap stdout and stderr in sync writers to ensure that writes exceeding
 	// PAGE_SIZE (4KB) are not interleaved.
 
-	stdOutLock *sync.RWMutex = new(sync.RWMutex)
-	stdOut     io.Writer     = &syncWriter{w: os.Stdout}
-	errOut     io.Writer     = &syncWriter{w: os.Stderr}
+	stdOutLock           = new(sync.RWMutex)
+	stdOut     io.Writer = &syncWriter{w: os.Stdout}
+	errOut     io.Writer = &syncWriter{w: os.Stderr}
 
 	dbgEntries = entries.New()
 )


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
We have been seeing random gobox/pkg/log [failures](https://app.circleci.com/pipelines/github/getoutreach/litmus/860/workflows/4fd62025-64b4-47b1-b848-5f854791409f/jobs/3523) in the CI. The root cause is `SetOutput()` and `Write()` are called concurrently trying to set/read the `stdOut` object at the same time. This change puts a lock around the `stdOut` object to guard it so that it is thread safe.
<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
