### PR TITLE
fix: we don't want to wait for context to close the pool

### DIFF
--- a/pkg/async/pool/pool.go
+++ b/pkg/async/pool/pool.go
@@ -227,9 +227,9 @@ func (p *Pool) worker(ctx context.Context) {
 
 // Close blocks until all workers finshes current items and terminates
 func (p *Pool) Close() {
-	p.wg.Wait()
 	p.cancel(&orerr.ShutdownError{Err: context.Canceled})
 	close(p.closed)
+	p.wg.Wait()
 }
 
 // Schedule tries to schedule runner for processing in the pool

--- a/pkg/async/pool/pool_test.go
+++ b/pkg/async/pool/pool_test.go
@@ -88,6 +88,10 @@ func (suite) TestGracefullyStops(t *testing.T) {
 	assert.Assert(t, InDelta(float64(s.NumGoroutineWithWorkers),
 		float64(runtime.NumGoroutine()), float64(size+1)), "Num of Goroutine is higher then expected")
 	s.Pool.Close()
+
+	// We don't want to wait for the context to close the pool.
+	assert.Assert(t, WithinDuration(time.Now(), s.StartedAt, 50*time.Millisecond))
+
 	time.Sleep(5 * time.Millisecond)
 	// After close all workers goroutines are dead
 	assert.Assert(t, InDelta(float64(s.NumGoroutineOnStart),


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
