### PR TITLE
feat(cli): Better shell completion support.

### DIFF
--- a/pkg/cli/bootstrap.go
+++ b/pkg/cli/bootstrap.go
@@ -162,12 +162,67 @@ func setupExitHandler(ctx context.Context) (exitCode *int, exit func()) {
 	return
 }
 
+// Returns true if the last argument to the program is
+// --generate-bash-completion, the special hidden flag urfave creates.
+// See: https://cli.urfave.org/v2/#bash-completion
+func isBashCompletion(lastArg string) bool {
+	return lastArg == "--generate-bash-completion"
+}
+
+// Returns true if the last argument to the program is
+// --generate-fish-completion, a special hidden flag gobox creates. This prints
+// the results of ToFishCompletion to stdout.
+// See: https://github.com/urfave/cli/blob/8b23e7b1e99f37934e029ef6c8d31efc7e744ff1/fish.go
+func isFishCompletion(lastArg string) bool {
+	return lastArg == "--generate-fish-completion"
+}
+
+// Attemps to generate shell completion.
+// Returns an error if genration fails, or if the last of the given args doesn't
+// match a completion flag.
+func generateShellCompletion(ctx context.Context, a *cli.App, args []string) error {
+	// First, inject the updater flags so that they show up in the help.
+	a.Flags = append(a.Flags, updater.UpdaterFlags...)
+	lastArg := args[len(args)-1]
+	switch {
+	case isBashCompletion(lastArg):
+		// Shell completion is handled by urfave.
+		return a.RunContext(ctx, args)
+	case isFishCompletion(lastArg):
+		// Print out fish completion.
+		completion, err := a.ToFishCompletion()
+		if err != nil {
+			return err
+		}
+		writer := a.Writer
+		if writer == nil {
+			writer = os.Stdout
+		}
+		fmt.Fprintln(writer, completion)
+		return nil
+	default:
+		return fmt.Errorf("generateShellCompletion called inappropriately")
+	}
+}
+
 // HookInUrfaveCLI sets up an app.Before that automatically traces command runs
 // and automatically updates itself.
 //
 //nolint:funlen // Why: Also not worth doing at the moment, we split a lot of this out already.
 func HookInUrfaveCLI(ctx context.Context, cancel context.CancelFunc, a *cli.App,
 	logger logrus.FieldLogger, honeycombAPIKey, dataset, teleforkAPIKey string) {
+	// Quick exit if this is asking for a shell completion. We do this before
+	// setting up any hooks or checking for updates to keep things speedy.
+	lastArg := os.Args[len(os.Args)-1]
+	if a.EnableBashCompletion && (isBashCompletion(lastArg) || isFishCompletion(lastArg)) {
+		if err := generateShellCompletion(ctx, a, os.Args); err != nil {
+			// This will be invisible to the user, most likely - but log for
+			// deubgging.
+			logger.Errorf("failed to generate completion: %v", err)
+		}
+		return
+	}
+
 	env.ApplyOverrides()
 	app.SetName(a.Name)
 

--- a/pkg/cli/bootstrap_test.go
+++ b/pkg/cli/bootstrap_test.go
@@ -2,8 +2,13 @@ package cli
 
 import (
 	"context"
+	"os"
+	"regexp"
 	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/urfave/cli/v2"
 )
 
 func TestCommonProps(t *testing.T) {
@@ -38,4 +43,56 @@ Since it's a simple test, the tradeoff seems reasonable.`)
 	overrideConfigLoaders("", "", false)
 	ctx := context.Background()
 	setupTracer(ctx, t.Name())
+}
+
+func TestGenerateShellCompletion(t *testing.T) {
+	// urfave requires arguments be set in `os.Args`. Capture the current value
+	// and restore at the end of the test.
+	startingArgs := os.Args
+	defer func() {
+		os.Args = startingArgs
+	}()
+
+	for _, fixture := range []struct {
+		args                []string
+		expectsErr          bool
+		expectedOutputRegex string
+	}{
+		// Ensure we get the --skip-update flag suggested for both flag
+		// generations.
+		{[]string{"-", "--generate-bash-completion"}, false, "--skip-update"},
+		{[]string{"--generate-fish-completion"}, false, "-l skip-update"},
+		// Ensure we get the boolean flag we created.
+		{[]string{"--t", "--generate-bash-completion"}, false, "--test-flag"},
+		{[]string{"--generate-fish-completion"}, false, "-l test-flag"},
+		// This should return an error, since the last flag isn't a completion request flag.
+		{[]string{"--test-flag"}, true, ""},
+	} {
+		var sb strings.Builder
+		app := cli.NewApp()
+		app.Name = "test-app"
+		app.Flags = []cli.Flag{
+			&cli.BoolFlag{Name: "test-flag", Usage: "Flips the flag"},
+		}
+		app.EnableBashCompletion = true
+		app.Writer = &sb
+		ctx := context.Background()
+
+		fullArgs := []string{"test-app"}
+		fullArgs = append(fullArgs, fixture.args...)
+		lastArg := fixture.args[len(fixture.args)-1]
+		os.Args = fullArgs
+
+		err := generateShellCompletion(ctx, app, fullArgs)
+		if err != nil != fixture.expectsErr {
+			t.Errorf(
+				"expected err != nil to be %t, got %t (err=%s) for lastArg=%s", fixture.expectsErr, err == nil, err, lastArg,
+			)
+		}
+		if matched, err := regexp.MatchString(fixture.expectedOutputRegex, sb.String()); err != nil {
+			t.Errorf("bad regular expression %s", fixture.expectedOutputRegex)
+		} else if !matched {
+			t.Errorf("expected string %s; got '%s' for lastArg=%s", fixture.expectedOutputRegex, sb.String(), lastArg)
+		}
+	}
 }

--- a/pkg/cli/updater/urfave_cli.go
+++ b/pkg/cli/updater/urfave_cli.go
@@ -24,21 +24,24 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// The urfave flags the updater will inject.
+var UpdaterFlags = []cli.Flag{
+	&cli.BoolFlag{
+		Name:  "skip-update",
+		Usage: "skips the updater check",
+	},
+	&cli.BoolFlag{
+		Name:  "force-update-check",
+		Usage: "Force checking for an update",
+	},
+}
+
 // hookIntoCLI hooks into a urfave/cli.App to add updater support
 func (u *updater) hookIntoCLI() {
 	oldBefore := u.app.Before
 
 	// append the standard flags
-	u.app.Flags = append(u.app.Flags, []cli.Flag{
-		&cli.BoolFlag{
-			Name:  "skip-update",
-			Usage: "skips the updater check",
-		},
-		&cli.BoolFlag{
-			Name:  "force-update-check",
-			Usage: "Force checking for an update",
-		},
-	}...)
+	u.app.Flags = append(u.app.Flags, UpdaterFlags...)
 
 	u.app.Before = func(c *cli.Context) error {
 		// Handle deprecations and parse the flags onto our updater struct


### PR DESCRIPTION
## What this PR does / why we need it

Eject into shell completion mode immediately, without completing logging and tracing setup. This dramatically increases the responsiveness of shell completion, and also avoids injecting updater messages into the completion suggestions.

Add a special flag for fish completion, since there is none built-in for urfave.

## Notes for your reviewers

See [the urfave manual](https://cli.urfave.org/v2/#bash-completion) for details on bash / zsh / powershell completion. The TL;DR is urfave supplies [helper scripts](https://github.com/urfave/cli/tree/8b23e7b1e99f37934e029ef6c8d31efc7e744ff1/autocomplete) that you can source to make completion work.

Fish support [exists](https://github.com/urfave/cli/blob/8b23e7b1e99f37934e029ef6c8d31efc7e744ff1/fish.go), but is undocumented in the manual and kind of wonky, since you must invoke it separately. Additionally, the implementation creates a completion script that would be sourced once at shell startup, since that allows for faster completion (you don't need to invoke the urfave binary again).

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
