### PR TITLE
feat(updater/resolver): support constraints (DT-2120)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.4
-	github.com/blang/semver/v4 v4.0.0
+	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/briandowns/spinner v1.18.1
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/Masterminds/semver/v3 v3.0.3 h1:znjIyLfpXEDQjOIEWh+ehwpTU14UzUPub3c3sm36u14=
 github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -84,8 +85,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/briandowns/spinner v1.18.1 h1:yhQmQtM1zsqFsouh09Bk/jCjd50pC3EOGsh28gLVvwY=
 github.com/briandowns/spinner v1.18.1/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=

--- a/pkg/cli/updater/misc.go
+++ b/pkg/cli/updater/misc.go
@@ -6,7 +6,7 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 	"github.com/charmbracelet/glamour"
 	"github.com/manifoldco/promptui"
 	"github.com/sirupsen/logrus"
@@ -33,19 +33,19 @@ func getRepoFromBuild() (string, error) {
 // true if we should continue, or false if we shouldn't
 func handleMajorVersion(log logrus.FieldLogger, curV, newV, relNotes string) bool {
 	// we skip errors because the above logic already parsed these version strings
-	cver, err := semver.ParseTolerant(curV)
+	cver, err := semver.NewVersion(curV)
 	if err != nil {
 		return true
 	}
 
-	nver, err := semver.ParseTolerant(newV)
+	nver, err := semver.NewVersion(newV)
 	if err != nil {
 		return true
 	}
 
 	// if the current major is less than the new release
 	// major then just return
-	if !(cver.Major < nver.Major) {
+	if !(cver.Major() < nver.Major()) {
 		return true
 	}
 

--- a/pkg/cli/updater/release/release.go
+++ b/pkg/cli/updater/release/release.go
@@ -34,11 +34,12 @@ type FetchOptions struct {
 	// Tag is the tag of the release
 	Tag string
 
-	// AssetName is the name of the asset to fetch
+	// AssetName is the name of the asset to fetch, globs are
+	// supported.
 	AssetName string
 
 	// AssetNames is a list of asset names to fetch, the first
-	// asset that matches will be returned.
+	// asset that matches will be returned. Globs are supported.
 	AssetNames []string
 }
 

--- a/pkg/cli/updater/resolver/resolver.go
+++ b/pkg/cli/updater/resolver/resolver.go
@@ -203,7 +203,7 @@ func getVersions(ctx context.Context, token cfg.SecretData, url string) (map[str
 // semver library used. In order to support this we parse the constraints to determine the allowed channels. By
 // default `stable` is always considered, with whatever pre-release (e.g. `>=1.0.0-alpha` -> `alpha`) is specified
 // in the pre-release constraint being added to the allowed channels. If a channel is specified, it is also added
-// to the allowed channels.
+// to the allowed channels. Due to this '&&' and '||' are not supported in constraints.
 func Resolve(ctx context.Context, token cfg.SecretData, c *Criteria) (*Version, error) {
 	versions, err := GetVersions(ctx, token, c.URL)
 	if err != nil {

--- a/pkg/cli/updater/resolver/resolver.go
+++ b/pkg/cli/updater/resolver/resolver.go
@@ -12,8 +12,9 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
-	"github.com/blang/semver/v4"
+	"github.com/Masterminds/semver/v3"
 	"github.com/getoutreach/gobox/pkg/cfg"
 	"github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
@@ -28,6 +29,15 @@ import (
 // https://regex101.com/r/yWXH5i/1
 var mutableTagRegex = regexp.MustCompile(`^[a-z-]+$`)
 
+// oprStripRegex is the regex to use to strip operators from a constraint
+var oprStripRegex = regexp.MustCompile(`^\D+(\d)`)
+
+// This block contains error types for the resolver package.
+var (
+	// ErrNoVersions is returned when no versions are found
+	ErrNoVersions = errors.New("no version found matching criteria")
+)
+
 // StableChannel is the default channel used when a version
 // doesn't contain a channel.
 const StableChannel = "stable"
@@ -40,6 +50,10 @@ type Criteria struct {
 	// Channel is the channel to use for determining the latest version.
 	// Leave empty to use the StableChannel.
 	Channel string
+
+	// Constraints are the semver constraint(s) to use for determining the latest version.
+	// See: https://pkg.go.dev/github.com/Masterminds/semver/v3#hdr-Checking_Version_Constraints_and_Comparing_Versions
+	Constraints []string
 }
 
 // Version is a resolved version from a git repository
@@ -50,7 +64,7 @@ type Version struct {
 
 	// sv is the semver version of the tag if it is a semver tag
 	// note: if mutable == true, not semver
-	sv semver.Version
+	sv *semver.Version
 
 	// Tag is the git tag that represents the version.
 	Tag string `yaml:"version"`
@@ -71,6 +85,44 @@ func (v *Version) String() string {
 	}
 
 	return v.Tag
+}
+
+// NewVersion creates a new version from a tag and commit.
+func NewVersion(tag, hash string) (*Version, error) {
+	var v Version
+
+	// Attempt to parse the tag as semver for a normal version
+	// tag.
+	//nolint:gocritic // Why: A switch statement doesn't read well.
+	if semV, err := semver.NewVersion(tag); err == nil {
+		// Determine the channel from the tag
+		// `v1.0.0-alpha.1` -> `alpha`
+		// `v1.0.0-unstable+commit` -> `unstable`
+		channel := StableChannel
+		splPre := strings.Split(semV.Prerelease(), ".")
+		if len(splPre) > 0 && splPre[0] != "" {
+			channel = splPre[0]
+		}
+
+		v = Version{
+			sv:      semV,
+			Tag:     tag,
+			Commit:  hash,
+			Channel: channel,
+		}
+	} else if mutableTagRegex.MatchString(tag) {
+		// Matches mutable tag format, so handle it as one
+		v = Version{
+			mutable: true,
+			Tag:     tag,
+			Commit:  hash,
+			Channel: tag,
+		}
+	} else {
+		return nil, errors.Errorf("tag %q is not a valid version", tag)
+	}
+
+	return &v, nil
 }
 
 // GetVersions returns all known channels and the versions that are available
@@ -111,38 +163,9 @@ func getVersions(ctx context.Context, token cfg.SecretData, url string) (map[str
 			continue
 		}
 
-		tagName := ref.Name().Short()
-		var v Version
-
-		// Attempt to parse the tag as semver for a normal version
-		// tag.
-		//nolint:gocritic // Why: A switch statement doesn't read well.
-		if semV, err := semver.ParseTolerant(tagName); err == nil {
-			// Determine the channel from the tag
-			// `v1.0.0-alpha.1` -> `alpha`
-			// `v1.0.0-unstable+commit` -> `beta`
-			channel := StableChannel
-			if len(semV.Pre) > 0 {
-				channel = semV.Pre[0].String()
-			}
-
-			v = Version{
-				sv:      semV,
-				Tag:     tagName,
-				Commit:  ref.Hash().String(),
-				Channel: channel,
-			}
-		} else if mutableTagRegex.MatchString(tagName) {
-			// Matches mutable tag format, so handle it as one
-			v = Version{
-				mutable: true,
-				Tag:     tagName,
-				Commit:  ref.Hash().String(),
-				Channel: tagName,
-			}
-		} else {
-			// didn't match any of the above, so it is an invalid tag
-			// skip.
+		v, err := NewVersion(ref.Name().Short(), ref.Hash().String())
+		if err != nil {
+			// IDEA(jaredallard): Some way to log this tag has been ignored?
 			continue
 		}
 
@@ -151,7 +174,7 @@ func getVersions(ctx context.Context, token cfg.SecretData, url string) (map[str
 			channels[v.Channel] = []Version{}
 		}
 
-		channels[v.Channel] = append(channels[v.Channel], v)
+		channels[v.Channel] = append(channels[v.Channel], *v)
 	}
 
 	// sort the versions
@@ -166,6 +189,21 @@ func getVersions(ctx context.Context, token cfg.SecretData, url string) (map[str
 //
 // Note: token is _optional_, if you do not wish to authenticate with your VCS
 // provider you can pass an empty string.
+//
+// Criteria:
+//
+// Constraints are supported as per the underlying semver library here:
+// https://pkg.go.dev/github.com/Masterminds/semver/v3#hdr-Checking_Version_Constraints_and_Comparing_Versions
+//
+// If a channel is provided, without a constraint, the latest version of that channel will be returned if it's
+// greater than the `stable` channel (if present). As a special case, if a channel's latest version is mutable,
+// that version will always be returned over any constraint.
+//
+// Constraints, by default, do not include a pre-releases or allow selecting specific pre-releases tracks in the
+// semver library used. In order to support this we parse the constraints to determine the allowed channels. By
+// default `stable` is always considered, with whatever pre-release (e.g. `>=1.0.0-alpha` -> `alpha`) is specified
+// in the pre-release constraint being added to the allowed channels. If a channel is specified, it is also added
+// to the allowed channels.
 func Resolve(ctx context.Context, token cfg.SecretData, c *Criteria) (*Version, error) {
 	versions, err := GetVersions(ctx, token, c.URL)
 	if err != nil {
@@ -181,33 +219,157 @@ func Resolve(ctx context.Context, token cfg.SecretData, c *Criteria) (*Version, 
 		return nil, errors.Errorf("unknown channel %q", c.Channel)
 	}
 
-	v := getLatestVersion(versions[c.Channel])
-	if v == nil {
-		return nil, fmt.Errorf("no version found matching criteria")
+	return getLatestVersion(versions, c)
+}
+
+// stringInSlice returns true if the string is in the slice
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// getLatestSatisfyingConstraint returns the latest version that satisfies the constraint
+func getLatestSatisfyingConstraint(versions map[string][]Version, c *Criteria) (*Version, error) {
+	allowedChannels := []string{c.Channel}
+	if c.Channel != StableChannel {
+		// always allow stable channel versions
+		allowedChannels = append(allowedChannels, StableChannel)
 	}
 
-	// check if the stable version is greater than the latest version inside
-	// of our requested version, if so, use that.
-	//
-	// However, when using a mutable tag, do not automatically promote because
-	// we can't actually tell, reliably, when the version is greater, or lesser,
-	// than the stable version.
-	if c.Channel != StableChannel && !v.mutable {
-		stableV := getLatestVersion(versions[StableChannel])
-		if stableV != nil {
-			latestV := getLatestVersion([]Version{*v, *stableV})
-			if latestV != nil && latestV != v {
-				v = latestV
+	// we have a constraint, so find the latest version that satisfies it
+	constraints := make([]*semver.Constraints, len(c.Constraints))
+	for i, constraintStr := range c.Constraints {
+		// Limit the ability to use && and || in constraints so we can mutate the constraint
+		// to allow pre-releases
+		if strings.Contains(constraintStr, "&&") || strings.Contains(constraintStr, "||") {
+			return nil, errors.Errorf("multiple constraints within a single constraint are not supported")
+		}
+
+		// strip space from the constraint
+		constraintStr = strings.TrimSpace(constraintStr)
+		if constraintStr == "*" {
+			// for some reason * doesn't work with the prereleases hack we use below,
+			// so convert * into >= 0.0.0, it's equivalent.
+			constraintStr = ">=0.0.0"
+		}
+
+		// extract allowed channels from the constraint if there is one
+		exampleVer := oprStripRegex.ReplaceAllString(constraintStr, "$1")
+		fmt.Println(exampleVer)
+		if exampleVerSem, err := semver.NewVersion(exampleVer); err == nil {
+			channel := strings.Split(exampleVerSem.Prerelease(), ".")[0]
+
+			if channel != "" {
+				alreadyHasChannel := stringInSlice(channel, allowedChannels)
+				if !alreadyHasChannel {
+					allowedChannels = append(allowedChannels, channel)
+				}
+			}
+		}
+
+		// If we're allowing channels other than the stable channel then we need to
+		// mutate the constraint to allow pre-releases. The constraint matching doesn't
+		// allow you to specify which pre-releases to allow, so we just allow all here
+		// and filter it down later.
+		if c.Channel != StableChannel {
+			constraintStr += "-" + "prereleases"
+		}
+
+		constraint, err := semver.NewConstraint(constraintStr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse constraint %q", constraintStr)
+		}
+
+		constraints[i] = constraint
+	}
+
+	// join all the versions into a single slice to consider for the constraint
+	allVersions := make([]*Version, 0)
+	for _, vers := range versions {
+		for i := range vers {
+			allVersions = append(allVersions, &vers[i])
+		}
+	}
+
+	// find the latest version that satisfies the constraint
+	var selectedVersion *Version
+	for _, v := range allVersions {
+		// if we find a mutable version, always skip it. They must be explicitly
+		// selected.
+		if v.mutable {
+			continue
+		}
+
+		// ensure this version meets all constraints
+		matchesConstraints := true
+		for _, constraint := range constraints {
+			// if the version isn't within our allowed channels, skip it
+			if !stringInSlice(v.Channel, allowedChannels) {
+				matchesConstraints = false
+				break
+			}
+
+			// if the version doesn't match the constraint, skip it
+			if !constraint.Check(v.sv) {
+				matchesConstraints = false
+				break
+			}
+		}
+		if matchesConstraints {
+			// Select the version if we don't have one, otherwise if the version we found is
+			// greater than the currently selected version, select it.
+			if selectedVersion == nil || v.sv.GreaterThan(selectedVersion.sv) {
+				selectedVersion = v
 			}
 		}
 	}
 
-	return v, nil
+	return selectedVersion, nil
 }
 
-// getLatestVersion returns the latest versions from a slice of versions.
+// getLatestVersion returns the latest based on the provided criteria, if a constraint
+// is provided it will be used to select the latest version that satisfies the constraint.
+//
+// See Resolve() comment for more details on the overall behaviour this implements.
+func getLatestVersion(versions map[string][]Version, c *Criteria) (*Version, error) {
+	// Note: selectedVersion may be nil at any point in time, until the end
+	// of the function where the default is handled
+	var selectedVersion *Version
+
+	// get the latest version from the channel if we don't have a constraint
+	if len(c.Constraints) == 0 {
+		// if latest version for the channel is mutable, return that. We don't support
+		// upgrading mutable (non-semver) versions to the stable channel or doing version
+		// constraints.
+		cv := getLatestVersionFromSlice(versions[c.Channel])
+		if cv.mutable {
+			return cv, nil
+		}
+
+		// Consider all versions if we don't have a constraint
+		c.Constraints = []string{">=0.0.0"}
+	}
+
+	// we have a constraint, so find the latest version that satisfies it
+	var err error
+	selectedVersion, err = getLatestSatisfyingConstraint(versions, c)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get latest version within constraints")
+	}
+	if selectedVersion == nil {
+		return nil, ErrNoVersions
+	}
+
+	return selectedVersion, nil
+}
+
+// getLatestVersionFromSlice returns the latest versions from a slice of versions.
 // This does not mutate the provided slice, and it does not need to be sorted.
-func getLatestVersion(argVersions []Version) *Version {
+func getLatestVersionFromSlice(argVersions []Version) *Version {
 	vers := make([]Version, len(argVersions))
 	copy(vers, argVersions)
 	Sort(vers)

--- a/pkg/cli/updater/resolver/resolver.go
+++ b/pkg/cli/updater/resolver/resolver.go
@@ -275,7 +275,7 @@ func getLatestSatisfyingConstraint(versions map[string][]Version, c *Criteria) (
 		// allow you to specify which pre-releases to allow, so we just allow all here
 		// and filter it down later.
 		if c.Channel != StableChannel && !strings.Contains(constraintStr, "-") {
-			constraintStr += "-" + "prereleases"
+			constraintStr += "-prereleases"
 		}
 
 		constraint, err := semver.NewConstraint(constraintStr)

--- a/pkg/cli/updater/resolver/resolver.go
+++ b/pkg/cli/updater/resolver/resolver.go
@@ -259,7 +259,6 @@ func getLatestSatisfyingConstraint(versions map[string][]Version, c *Criteria) (
 
 		// extract allowed channels from the constraint if there is one
 		exampleVer := oprStripRegex.ReplaceAllString(constraintStr, "$1")
-		fmt.Println(exampleVer)
 		if exampleVerSem, err := semver.NewVersion(exampleVer); err == nil {
 			channel := strings.Split(exampleVerSem.Prerelease(), ".")[0]
 

--- a/pkg/cli/updater/resolver/resolver_test.go
+++ b/pkg/cli/updater/resolver/resolver_test.go
@@ -206,6 +206,20 @@ func TestResolve(t *testing.T) {
 			want: newTestingVersion("v0.9.2-beta.1"),
 		},
 		{
+			name: "should support comparing rc versions",
+			c:    Criteria{Constraints: []string{">=0.9.1-rc.1"}},
+			versions: map[string][]Version{
+				StableChannel: {
+					newTestingVersion("v0.9.0"),
+				},
+				"rc": {
+					newTestingVersion("v0.9.1-rc.1"),
+					newTestingVersion("v0.9.1-rc.2"),
+				},
+			},
+			want: newTestingVersion("v0.9.1-rc.2"),
+		},
+		{
 			name: "should support branches",
 			c:    Criteria{Channel: "main", AllowBranches: true},
 			versions: map[string][]Version{

--- a/pkg/cli/updater/resolver/resolver_test.go
+++ b/pkg/cli/updater/resolver/resolver_test.go
@@ -301,7 +301,7 @@ func Test_getVersions(t *testing.T) {
 					if gotV.Channel != expectedV.Channel ||
 						(gotV.Commit != expectedV.Commit && expectedV.Commit != "skip-validate") ||
 						gotV.Tag != expectedV.Tag ||
-						gotV.mutable != expectedV.mutable ||
+						gotV.Mutable != expectedV.Mutable ||
 						!reflect.DeepEqual(gotV.sv, expectedV.sv) {
 						t.Errorf("getVersions() = %v, want %v", gotV, expectedV)
 						return

--- a/pkg/cli/updater/resolver/resolver_test.go
+++ b/pkg/cli/updater/resolver/resolver_test.go
@@ -166,6 +166,40 @@ func TestResolve(t *testing.T) {
 			},
 			want: newTestingVersion("v0.9.1-rc.1"),
 		},
+		{
+			name: "should support channel with constraint wanting another channel",
+			c:    Criteria{Channel: "rc", Constraints: []string{">=0.9.1-beta"}},
+			versions: map[string][]Version{
+				StableChannel: {
+					newTestingVersion("v0.9.0"),
+				},
+				"rc": {
+					newTestingVersion("v0.9.1-rc.1"),
+				},
+				"beta": {
+					newTestingVersion("v0.9.2-beta.1"),
+				},
+			},
+			// should return beta because module asked for it
+			want: newTestingVersion("v0.9.2-beta.1"),
+		},
+		{
+			name: "should support channel being gtr with constraint wanting another channel",
+			c:    Criteria{Channel: "beta", Constraints: []string{">=0.9.1-rc"}},
+			versions: map[string][]Version{
+				StableChannel: {
+					newTestingVersion("v0.9.0"),
+				},
+				"rc": {
+					newTestingVersion("v0.9.1-rc.1"),
+				},
+				"beta": {
+					newTestingVersion("v0.9.2-beta.1"),
+				},
+			},
+			// should return beta because channel asked for it
+			want: newTestingVersion("v0.9.2-beta.1"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cli/updater/resolver/sort.go
+++ b/pkg/cli/updater/resolver/sort.go
@@ -24,12 +24,12 @@ func (s Versions) Swap(i, j int) {
 func (s Versions) Less(i, j int) bool {
 	// if either of these versions are mutable, they are always
 	// ranked less than the other.
-	if s[i].mutable {
+	if s[i].Mutable {
 		// less than j
 		return true
 	}
 
-	if s[j].mutable {
+	if s[j].Mutable {
 		// greater than i
 		return false
 	}

--- a/pkg/cli/updater/resolver/sort.go
+++ b/pkg/cli/updater/resolver/sort.go
@@ -34,7 +34,7 @@ func (s Versions) Less(i, j int) bool {
 		return false
 	}
 
-	return s[i].sv.LT(s[j].sv)
+	return s[i].sv.LessThan(s[j].sv)
 }
 
 // Sort sorts a slice of versions

--- a/pkg/cli/updater/urfave_cli.go
+++ b/pkg/cli/updater/urfave_cli.go
@@ -236,7 +236,7 @@ func newSetChannel(u *updater) *cli.Command {
 				return fmt.Errorf("channel must be provided")
 			}
 
-			versions, err := resolver.GetVersions(c.Context, u.ghToken, u.repoURL)
+			versions, err := resolver.GetVersions(c.Context, u.ghToken, u.repoURL, false)
 			if err != nil {
 				return errors.Wrap(err, "failed to determine channels from remote")
 			}
@@ -276,7 +276,7 @@ func newGetChannels(u *updater) *cli.Command {
 		Name:  "get-channels",
 		Usage: "Returns the valid channels",
 		Action: func(c *cli.Context) error {
-			versions, err := resolver.GetVersions(c.Context, u.ghToken, u.repoURL)
+			versions, err := resolver.GetVersions(c.Context, u.ghToken, u.repoURL, false)
 			if err != nil {
 				return errors.Wrap(err, "failed to determine channels from remote")
 			}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds [constraint support](https://pkg.go.dev/github.com/Masterminds/semver/v3#hdr-Checking_Version_Constraints_and_Comparing_Versions) to the version resolver used by the updater. This allows other consumers to add semver constraints to change the versions selected by the resolver.

The general behaviour of this package is well documented in the tests written, but also in the package comment for `Resolve`, copied here for posterity:

```go
// Resolve returns the latest version that satisfies the criteria
//
// Note: token is _optional_, if you do not wish to authenticate with your VCS
// provider you can pass an empty string.
//
// Criteria:
//
// Constraints are supported as per the underlying semver library here:
// https://pkg.go.dev/github.com/Masterminds/semver/v3#hdr-Checking_Version_Constraints_and_Comparing_Versions
//
// If a channel is provided, without a constraint, the latest version of that channel will be returned if it's
// greater than the `stable` channel (if present). As a special case, if a channel's latest version is mutable,
// that version will always be returned over any constraint.
//
// Constraints, by default, do not include a pre-releases or allow selecting specific pre-releases tracks in the
// semver library used. In order to support this we parse the constraints to determine the allowed channels. By
// default `stable` is always considered, with whatever pre-release (e.g. `>=1.0.0-alpha` -> `alpha`) is specified
// in the pre-release constraint being added to the allowed channels. If a channel is specified, it is also added
// to the allowed channels.
func Resolve(ctx context.Context, token cfg.SecretData, c *Criteria) (*Version, error) {
```

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2120]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2120]: https://outreach-io.atlassian.net/browse/DT-2120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ