### PR TITLE
feat(trace): SpanStartOption and WithLinks

### DIFF
--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -193,11 +193,22 @@ func (t *otelTracer) id(ctx context.Context) string {
 	return ""
 }
 
-func (t *otelTracer) startSpan(ctx context.Context, name string) context.Context {
+func (t *otelTracer) startSpan(ctx context.Context, name string, opts ...SpanStartOption) context.Context {
 	tracer := otel.GetTracerProvider().Tracer(t.serviceName)
-	ctx, _ = tracer.Start(ctx, name)
+	ctx, _ = tracer.Start(ctx, name, t.toOtelOptions(opts)...)
 
 	return ctx
+}
+
+func (t *otelTracer) toOtelOptions(opts []SpanStartOption) []trace.SpanStartOption {
+	otelOpts := []trace.SpanStartOption{}
+	for _, opt := range opts {
+		otelOpt := opt.otelOption(t)
+		if otelOpt != nil {
+			otelOpts = append(otelOpts, otelOpt)
+		}
+	}
+	return otelOpts
 }
 
 func (t *otelTracer) startSpanAsync(ctx context.Context, name string) context.Context {

--- a/pkg/trace/span_start_options.go
+++ b/pkg/trace/span_start_options.go
@@ -23,22 +23,20 @@ type SpanStartOption interface {
 // and the linked contexts come from 'outside' by other means (e.g. clerk system event headers).
 // In case you need to link trace with a span and you have direct access to that Span's context,
 // you can use trace.ToHeaders to extract the same headers map.
-func WithLink(traceHeaders map[string][]string, name string) SpanStartOption {
-	return linkOption{traceHeaders: traceHeaders, name: name}
+func WithLink(traceHeaders map[string][]string) SpanStartOption {
+	return linkOption{traceHeaders: traceHeaders}
 }
 
 // linkOption implements SpanStartOption
 type linkOption struct {
 	// traceHeaders to create span from
 	traceHeaders map[string][]string
-	// name to use for the linked span
-	name string
 }
 
 // otelOption generates a link to be attached to the StartSpan call
 func (o linkOption) otelOption(t *otelTracer) trace.SpanStartOption {
 	// must have fresh context as an input to avoid any external pollution of the span context
-	linkCtx := t.fromHeaders(context.Background(), o.traceHeaders, o.name)
+	linkCtx := t.contextFromHeaders(context.Background(), o.traceHeaders)
 	link := trace.LinkFromContext(linkCtx)
 	return trace.WithLinks(link)
 }

--- a/pkg/trace/span_start_options.go
+++ b/pkg/trace/span_start_options.go
@@ -1,0 +1,44 @@
+package trace
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// SpanStartOption is an interface for various options to be provided
+// during span creation (StartSpan).
+type SpanStartOption interface {
+	// otelOption converts the current option to the native otel's SpanStartOption
+	// it is intentionally unexported to block external implementations of SpanStartOption
+	otelOption(t *otelTracer) trace.SpanStartOption
+}
+
+// WithLink links an external span to the current one. The link can only happen
+// when trace span starts (they cannot be attached mid-span lifetime).
+//
+// The caller should not modify the argument traceHeaders map after calling WithLink.
+//
+// The method accepts trace headers as a map: assumption is current 'context' hosts the parent span
+// and the linked contexts come from 'outside' by other means (e.g. clerk system event headers).
+// In case you need to link trace with a span and you have direct access to that Span's context,
+// you can use trace.ToHeaders to extract the same headers map.
+func WithLink(traceHeaders map[string][]string, name string) SpanStartOption {
+	return linkOption{traceHeaders: traceHeaders, name: name}
+}
+
+// linkOption implements SpanStartOption
+type linkOption struct {
+	// traceHeaders to create span from
+	traceHeaders map[string][]string
+	// name to use for the linked span
+	name string
+}
+
+// otelOption generates a link to be attached to the StartSpan call
+func (o linkOption) otelOption(t *otelTracer) trace.SpanStartOption {
+	// must have fresh context as an input to avoid any external pollution of the span context
+	linkCtx := t.fromHeaders(context.Background(), o.traceHeaders, o.name)
+	link := trace.LinkFromContext(linkCtx)
+	return trace.WithLinks(link)
+}

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -207,6 +207,19 @@ func StartSpan(ctx context.Context, name string, args ...log.Marshaler) context.
 	return newCtx
 }
 
+// StartSpanWithOptions starts a new span, with extra start options (such as links to external spans).
+//
+// Use trace.End to end this.
+func StartSpanWithOptions(ctx context.Context, name string, opts []SpanStartOption, args ...log.Marshaler) context.Context {
+	if defaultTracer == nil {
+		return ctx
+	}
+
+	newCtx := defaultTracer.startSpan(ctx, name, opts...)
+	addDefaultTracerInfo(newCtx, args...)
+	return newCtx
+}
+
 // Deprecated: use StartSpan() instead. It will handle async traces automatically.
 // StartSpanAsync starts a new async span.
 //

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -320,7 +320,8 @@ func ToHeaders(ctx context.Context) map[string][]string {
 	return defaultTracer.toHeaders(ctx)
 }
 
-// FromHeaders fetches trace info from a headers map
+// FromHeaders fetches trace info from a headers map and starts a new Span on top of the extracted
+// span context (which can be either local or remote). You must end this context with End.
 //
 // Only use for GRPC. Prefer NewHandler for http calls.
 func FromHeaders(ctx context.Context, hdrs map[string][]string, name string) context.Context {

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -25,7 +25,7 @@ type tracer interface {
 
 	id(ctx context.Context) string
 
-	startSpan(ctx context.Context, name string) context.Context
+	startSpan(ctx context.Context, name string, opts ...SpanStartOption) context.Context
 
 	// Deprecated: Use startSpan() instead.
 	startSpanAsync(ctx context.Context, name string) context.Context

--- a/pkg/trace/tracetest/tracetest.go
+++ b/pkg/trace/tracetest/tracetest.go
@@ -99,6 +99,19 @@ func (sr *SpanRecorder) Ended() []map[string]interface{} {
 			spanInfo[key] = a.Value.AsString()
 		}
 
+		links := s.Links()
+		if len(links) > 0 {
+			var linksInfo []map[string]interface{}
+			for _, link := range links {
+				linkInfo := map[string]interface{}{
+					"spanContext.traceID": link.SpanContext.TraceID().String(),
+					"spanContext.spanID":  link.SpanContext.SpanID().String(),
+				}
+				linksInfo = append(linksInfo, linkInfo)
+			}
+			spanInfo["links"] = linksInfo
+		}
+
 		result = append(result, spanInfo)
 	}
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Clerk needs to link producer spans with consumer ones cross VM boundaries. In order to do so, we need gobox's trace support to start a span with a link. Clerk already propagates traceHeaders as part of the event, so this PR is to take the same headers (map[string][]string - same as existing To/FromHeaders methods) and generate a link out of them + attach the link as a new StartSpanOption. StartSpanOption abstracts out otel implementation ...

<!--- Block(jiraPrefix) --->

## Jira ID

[CDT-102]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[CDT-102]: https://outreach-io.atlassian.net/browse/CDT-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ