### PR TITLE
fix(trace): export SpanID

### DIFF
--- a/pkg/trace/call.go
+++ b/pkg/trace/call.go
@@ -148,7 +148,7 @@ type traceInfo struct {
 func (c traceInfo) MarshalLog(addField func(field string, value interface{})) {
 	addField("honeycomb.trace_id", ID(c))
 	addField("honeycomb.parent_id", parentID(c))
-	addField("honeycomb.span_id", spanID(c))
+	addField("honeycomb.span_id", SpanID(c))
 }
 
 type traceEventMarker struct{}

--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -203,7 +203,7 @@ func (t *otelTracer) startSpan(ctx context.Context, name string, opts ...SpanSta
 func (t *otelTracer) toOtelOptions(opts []SpanStartOption) []trace.SpanStartOption {
 	otelOpts := []trace.SpanStartOption{}
 	for _, opt := range opts {
-		otelOpt := opt.otelOption(t)
+		otelOpt := opt.otelOption()
 		if otelOpt != nil {
 			otelOpts = append(otelOpts, otelOpt)
 		}

--- a/pkg/trace/span_start_options.go
+++ b/pkg/trace/span_start_options.go
@@ -11,7 +11,7 @@ import (
 type SpanStartOption interface {
 	// otelOption converts the current option to the native otel's SpanStartOption
 	// it is intentionally unexported to block external implementations of SpanStartOption
-	otelOption(t *otelTracer) trace.SpanStartOption
+	otelOption() trace.SpanStartOption
 }
 
 // WithLink links an external span to the current one. The link can only happen
@@ -23,20 +23,40 @@ type SpanStartOption interface {
 // and the linked contexts come from 'outside' by other means (e.g. clerk system event headers).
 // In case you need to link trace with a span and you have direct access to that Span's context,
 // you can use trace.ToHeaders to extract the same headers map.
-func WithLink(traceHeaders map[string][]string) SpanStartOption {
-	return linkOption{traceHeaders: traceHeaders}
+func WithLink(traceHeaders map[string][]string) Link {
+	if defaultTracer == nil {
+		return Link{}
+	}
+
+	// must have fresh context as an input to avoid any external pollution on the linked context
+	return Link{linkContext: defaultTracer.contextFromHeaders(context.Background(), traceHeaders)}
 }
 
-// linkOption implements SpanStartOption
-type linkOption struct {
-	// traceHeaders to create span from
-	traceHeaders map[string][]string
+// Link implements SpanStartOption
+type Link struct {
+	// linkContext is a dummy context to store linked trace/span ID headers
+	linkContext context.Context
 }
+
+// TraceID returns the trace ID from the linked context or empty if such is unavailable
+func (l Link) TraceID() string {
+	return ID(l.linkContext)
+}
+
+// SpanID returns the span ID from the linked context or empty if such is unavailable
+func (l Link) SpanID() string {
+	return SpanID(l.linkContext)
+}
+
+// _ makes sure Link conforms with the SpanStartOption interface
+var _ SpanStartOption = Link{}
 
 // otelOption generates a link to be attached to the StartSpan call
-func (o linkOption) otelOption(t *otelTracer) trace.SpanStartOption {
-	// must have fresh context as an input to avoid any external pollution of the span context
-	linkCtx := t.contextFromHeaders(context.Background(), o.traceHeaders)
-	link := trace.LinkFromContext(linkCtx)
+func (l Link) otelOption() trace.SpanStartOption {
+	if l.linkContext == nil {
+		return nil
+	}
+
+	link := trace.LinkFromContext(l.linkContext)
 	return trace.WithLinks(link)
 }

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -269,9 +269,9 @@ func ID(ctx context.Context) string {
 	return defaultTracer.id(ctx)
 }
 
-// spanID returns the root tracing spanID for use when it is needed to correlate the logs belonging to same flow.
-// The spanID returned will be the honeycomb trace spanID (if honeycomb is enabled) or an empty string if neither are enabled
-func spanID(ctx context.Context) string {
+// SpanID returns the root tracing SpanID for use when it is needed to correlate the logs belonging to same flow.
+// The SpanID returned will be the honeycomb trace SpanID (if honeycomb is enabled) or an empty string if neither are enabled
+func SpanID(ctx context.Context) string {
 	if defaultTracer == nil {
 		return ""
 	}

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -50,5 +50,8 @@ type tracer interface {
 
 	toHeaders(ctx context.Context) map[string][]string
 
+	contextFromHeaders(ctx context.Context, hdrs map[string][]string) context.Context
+
+	// fromHeaders is similar to contextFromHeaders + it starts a new span
 	fromHeaders(ctx context.Context, hdrs map[string][]string, name string) context.Context
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This PR exposes SpanID as well as Trace and Span ID from the Link object. It also exports the former linkOption as a Link struct to allow callers access the trace/span IDs directly from the link.

Clerk needs to link a trace to process batch of clerk events to their producer's traces. If producer sent them in a batch, there is a good chance that there will be large overlaps between producer and consumer batches with span IDs, resulting in multiple links with same trace/span ID.

I checked otel's code - it does not deduplicate links. If the # of links is over limit (default 128), it will simply evict others.
https://github.com/open-telemetry/opentelemetry-go/blob/55b49c407e07dc13bdba245c2c13935a37bad971/sdk/trace/tracer.go#L144. SpanID is needed to deduplicate the links.


<!--- Block(jiraPrefix) --->

## Jira ID

[CDT-102]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
