### PR TITLE
chore: Unit test fixes.

### DIFF
--- a/pkg/async/pool/timeout_test.go
+++ b/pkg/async/pool/timeout_test.go
@@ -14,32 +14,38 @@ func TestTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	p := pool.New(ctx,
-		pool.ConstantSize(1),
-	)
+	p := pool.New(ctx, pool.ConstantSize(1))
 
 	startedAt := time.Now()
 
-	scheduler := pool.WithTimeout(5*time.Millisecond, p)
+	timeout := 5 * time.Millisecond
+	scheduler := pool.WithTimeout(timeout, p)
 
 	scheduler, wait := pool.WithWait(scheduler)
 
 	var err error
+	// The signal to start first scheduled task.
+	startFirst := make(chan bool)
+	defer close(startFirst)
 
 	scheduler.Schedule(ctx, async.Func(func(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		time.Sleep(10 * time.Millisecond)
+		<-startFirst
+		// Ensure the next task times out.
+		time.Sleep(2 * timeout)
 		return nil
 	}))
 	scheduler.Schedule(ctx, async.Func(func(ctx context.Context) error {
 		if ctx.Err() != nil {
+			// Capture context error in enclosing scope.
 			err = ctx.Err()
 			return ctx.Err()
 		}
 		return nil
 	}))
+	startFirst <- true
 
 	wait()
 

--- a/pkg/async/pool/wait.go
+++ b/pkg/async/pool/wait.go
@@ -7,8 +7,9 @@ import (
 	"github.com/getoutreach/gobox/pkg/async"
 )
 
-// Wait is a scheduler that allow you to wait until all scheduled tasks are processed or failed to enqueue.
-// It can be used when you need to wait for all items from one batch are processed
+// Wait is a scheduler that allows you to wait until all scheduled tasks are
+// processed or have failed to enqueue. It can be used when you need to wait
+// for all items from one batch to be processed.
 type Wait struct {
 	Scheduler Scheduler
 	sync.WaitGroup


### PR DESCRIPTION
## What this PR does / why we need it

Fix a test whose slow task would sometimes complete too early, breaking a timeout test.

Fix a test that would sometimes cancel too early, causing too few tasks to finish. Also load shared memory atomically, just for completeness.

Clean up some grammar in godoc.

## Notes for your reviewers

These tests are super-flaky, and hopefully this fixes them.