### PR TITLE
fix(updater): properly compare mutable versions

### DIFF
--- a/pkg/cli/updater/updater.go
+++ b/pkg/cli/updater/updater.go
@@ -340,7 +340,7 @@ func (u *updater) check(ctx context.Context) (bool, error) {
 
 // shouldUpdate returns true if the updater should update and the reason
 // why it should, or shouldn't as a string.
-func (u *updater) shouldUpdate(v *resolver.Version) (bool, string) {
+func (u *updater) shouldUpdate(v *resolver.Version) (bool, string) { //nolint:gocritic // Why: doc'd above
 	curV, err := resolver.NewVersionFromVersionString(u.version)
 	if err != nil {
 		return false, fmt.Sprintf("failed to parse current version: %s", err)

--- a/pkg/cli/updater/updater_test.go
+++ b/pkg/cli/updater/updater_test.go
@@ -2,8 +2,6 @@ package updater
 
 import (
 	"context"
-	"reflect"
-	"runtime"
 	"testing"
 	"time"
 
@@ -14,54 +12,6 @@ import (
 	"github.com/urfave/cli/v2"
 	"gotest.tools/v3/assert"
 )
-
-func Test_generatePossibleAssetNames(t *testing.T) {
-	type args struct {
-		name    string
-		version string
-	}
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{
-			name: "should generate all possible asset names",
-			args: args{
-				name:    "test",
-				version: "v1.0.0",
-			},
-			want: []string{
-				// v prefixes
-				"test_v1.0.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.xz",
-				"test_v1.0.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz",
-				"test_v1.0.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.bz2",
-				"test_v1.0.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".zip",
-				"test-v1.0.0-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.xz",
-				"test-v1.0.0-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz",
-				"test-v1.0.0-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.bz2",
-				"test-v1.0.0-" + runtime.GOOS + "-" + runtime.GOARCH + ".zip",
-
-				// without v prefixes
-				"test_1.0.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.xz",
-				"test_1.0.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz",
-				"test_1.0.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.bz2",
-				"test_1.0.0_" + runtime.GOOS + "_" + runtime.GOARCH + ".zip",
-				"test-1.0.0-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.xz",
-				"test-1.0.0-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz",
-				"test-1.0.0-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.bz2",
-				"test-1.0.0-" + runtime.GOOS + "-" + runtime.GOARCH + ".zip",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := generatePossibleAssetNames(tt.args.name, tt.args.version); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("generatePossibleAssetNames() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func Test_updater_defaultOptions(t *testing.T) {
 	defaultCheckInterval := 30 * time.Minute

--- a/pkg/cli/updater/urfave_cli.go
+++ b/pkg/cli/updater/urfave_cli.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -328,7 +329,20 @@ func newStatusCommand(u *updater) *cli.Command {
 
 			fmt.Println("Last Update Check:", lastCheckStr)
 			if !disabled {
-				fmt.Println("")
+				fmt.Println()
+				fmt.Println("Remote Information:")
+				v, err := resolver.Resolve(c.Context, u.ghToken, &resolver.Criteria{
+					URL:     u.repoURL,
+					Channel: u.channel,
+				})
+				if err != nil {
+					return errors.Wrap(err, "failed to resolve latest version")
+				}
+				fmt.Println("  Latest Version:", v.String())
+				shouldUpdate, reason := u.shouldUpdate(v)
+				fmt.Printf("  Update Reason: %s (should: %s)\n", reason, strconv.FormatBool(shouldUpdate))
+
+				fmt.Println()
 				fmt.Printf("Checking for updates again at %s\n", color.New(color.Bold).Sprint(nextCheck.Format(time.RFC1123)))
 			}
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR changes the updater to properly compare mutable versions, and providers a function to create a, lossy, mutable version from the version string.

This, combined with the new `LessThan` and `Equal` functions allows us to potentially use this logic other places (as it makes sense)

I also added this information to the `updater status` command so it'll be easier to track down why this happened in the future.

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2815]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2815]: https://outreach-io.atlassian.net/browse/DT-2815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ