### PR TITLE
feat: handle invalid semver, support go run/install/gobin

### DIFF
--- a/pkg/app/info.go
+++ b/pkg/app/info.go
@@ -9,13 +9,21 @@ import (
 	"sync"
 )
 
-// Version needs to be set at build time using -ldflags "-X github.com/getoutreach/gobox/pkg/app.Version=something"
-// nolint:gochecknoglobals
-var Version = "Please see http://github.com/getoutreach/gobox/blob/master/docs/version.md"
+// defaultVersion is the default version string
+const defaultVersion = "Please see http://github.com/getoutreach/gobox/blob/main/docs/version.md"
 
-// nolint:gochecknoglobals
+// Version needs to be set at build time using
+// -ldflags "-X github.com/getoutreach/gobox/pkg/app.Version=something"
+//
+//nolint:gochecknoglobals // Why: For linking
+var Version = defaultVersion
+
+// appName is the name of the app
+//
+//nolint:gochecknoglobals // Why: For linking
 var appName = "unknown"
 
+// appInfo contains information about the app
 var appInfo struct {
 	mu sync.Mutex // guarding Data to be set initialized concurrently
 	*Data
@@ -36,6 +44,8 @@ func Info() *Data {
 	return appInfo.Data
 }
 
+// info returns the static app info
+//
 //nolint:funlen
 func info() *Data {
 	const unknown = "unknown"
@@ -44,9 +54,15 @@ func info() *Data {
 	serviceAccount := ""
 	bento := ""
 
+	ver := Version
 	buildInfo, ok := debug.ReadBuildInfo()
 	if ok {
 		mainModule = buildInfo.Main.Path
+
+		// allow people to still link the version
+		if ver == defaultVersion {
+			ver = buildInfo.Main.Version
+		}
 	}
 
 	// The namespace and service account env vars are set by bootstrap
@@ -104,7 +120,7 @@ func info() *Data {
 
 	return &Data{
 		Name:    appName,
-		Version: Version,
+		Version: ver,
 
 		MainModule: mainModule,
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR makes the updater disable itself when an invalid version is provided. I also updated `app` to source version information, if not linked in, from the go module. This lets `go run` and (theoretically, I can't test w/o a release) work on `go install` (and `go run <module>@<revision>`). Unclear if this will support gobin, but it'll at least make `--skip-update` a valid argument.

Example on a locally compiled version of `smartstore` w/ `replace` for this version:

```bash
$ go run ./cmd/smartstore updater status
Version: (devel)
Channel:  ()
Updater Status: disabled (failed to parse current version as semver: Invalid Semantic Version)
Last Update Check: Mon, 26 Sep 2022 18:11:52 UTC
```

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2907]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2907]: https://outreach-io.atlassian.net/browse/DT-2907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ