### PR TITLE
fix(updater): fix updating binaries

### DIFF
--- a/pkg/cli/updater/updater.go
+++ b/pkg/cli/updater/updater.go
@@ -366,7 +366,13 @@ func (u *updater) installVersion(ctx context.Context, v *resolver.Version) error
 	a, aName, aSize, err := release.Fetch(ctx, u.ghToken, &release.FetchOptions{
 		RepoURL:   u.repoURL,
 		Tag:       v.Tag,
-		AssetName: filepath.Base(u.executablePath) + "_*_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.*",
+		
+		// Assets are uploaded starting with `repoName`. 
+		// Don't use filepath.Base(u.executableName),
+		// because if the executable is not named the same as the repo 
+		// (and there is no restriction for it be so)
+		// then the installer won't be able to find the asset.
+		AssetName: filepath.Base(u.repoURL) + "_*_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.*",
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch release")


### PR DESCRIPTION
Where the binary is not the same name as the repo

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
- Uses repoName instead of executableName
- Executable is not always named the same as the repo, but CI uploads assets that are the name of the repo.


<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
