### PR TITLE
feat: intro trace.IsSampled method

### DIFF
--- a/pkg/trace/force_sampler.go
+++ b/pkg/trace/force_sampler.go
@@ -78,6 +78,7 @@ func (s *otelForceSampler) isSampled(traceID string) bool {
 	return s.sampler.Sample(traceID)
 }
 
+// newSampler creates a new deterministic sampler for the given rate or panics if the rate is 0.
 func newSampler(sampleRate uint) *otelForceSampler {
 	sampler, err := sample.NewDeterministicSampler(sampleRate)
 	if err != nil {

--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -258,6 +258,8 @@ func (t *otelTracer) isForce() bool {
 	return t.force
 }
 
+// isSampled is used to determine if the given trace ID should be sampled based on the
+// current sample rate.
 func (t *otelTracer) isSampled(traceID string) bool {
 	return t.sampler.isSampled(traceID)
 }

--- a/pkg/trace/span_start_options.go
+++ b/pkg/trace/span_start_options.go
@@ -53,7 +53,10 @@ func (l Link) SpanID() string {
 //
 // This method can be used to significanylu reduce 'dead link URLs', assuming the sampling rate of
 // the producing app is same as the current one and also the hash used to calculate the sampling is
-// deterministic and same on both sides.
+// deterministic and same on both sides. However, it does not completely solve the issue, hence the
+// Jira item below to complete the picture.
+//
+// TODO[DT-3105]: introduce new trace header and method to pass the `is_sampled` state from the producer
 func (l Link) IsSampledIfLocal() bool {
 	if defaultTracer == nil {
 		return false

--- a/pkg/trace/span_start_options.go
+++ b/pkg/trace/span_start_options.go
@@ -48,6 +48,19 @@ func (l Link) SpanID() string {
 	return SpanID(l.linkContext)
 }
 
+// IsSampledIfLocal returns true if the linked trace would have been sampled if declared
+// as the local trace with the same ID.
+//
+// This method can be used to significanylu reduce 'dead link URLs', assuming the sampling rate of
+// the producing app is same as the current one and also the hash used to calculate the sampling is
+// deterministic and same on both sides.
+func (l Link) IsSampledIfLocal() bool {
+	if defaultTracer == nil {
+		return false
+	}
+	return defaultTracer.isSampled(l.TraceID())
+}
+
 // _ makes sure Link conforms with the SpanStartOption interface
 var _ SpanStartOption = Link{}
 

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -323,12 +323,3 @@ func FromHeaders(ctx context.Context, hdrs map[string][]string, name string) con
 	}
 	return defaultTracer.fromHeaders(ctx, hdrs, name)
 }
-
-// IsSampled returns true if the given trace ID is sampled based on the current sampling rate.
-// This API is mostly for remote trace ID correlation.
-func IsSampled(traceID string) bool {
-	if defaultTracer == nil {
-		return false
-	}
-	return defaultTracer.isSampled(traceID)
-}

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -323,3 +323,12 @@ func FromHeaders(ctx context.Context, hdrs map[string][]string, name string) con
 	}
 	return defaultTracer.fromHeaders(ctx, hdrs, name)
 }
+
+// IsSampled returns true if the given trace ID is sampled based on the current sampling rate.
+// This API is mostly for remote trace ID correlation.
+func IsSampled(traceID string) bool {
+	if defaultTracer == nil {
+		return false
+	}
+	return defaultTracer.isSampled(traceID)
+}

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -55,5 +55,7 @@ type tracer interface {
 	// fromHeaders is similar to contextFromHeaders + it starts a new span
 	fromHeaders(ctx context.Context, hdrs map[string][]string, name string) context.Context
 
+	// isSampled is used to determine if the given trace ID should be sampled based on the
+	// current sample rate
 	isSampled(traceID string) bool
 }

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -54,4 +54,6 @@ type tracer interface {
 
 	// fromHeaders is similar to contextFromHeaders + it starts a new span
 	fromHeaders(ctx context.Context, hdrs map[string][]string, name string) context.Context
+
+	isSampled(traceID string) bool
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This PR introduces IsSampled method to avoid prevention of 'dead links' in linking scenarios. E.g.:
* clerk producer attaches trace headers to clerk message
* clerk consumer reads trace header

Without the IsSampled: it always links to this header, but in Honeycomb this link will be DEAD. It is virtually impossible to show traces with link which are NOT dead - thus to find a trace with a valid link requires at least 100 clicks

With IsSampled: I will patch clerk code to only attach link if the source was sampled. Otherwise, it will be ignored. This way when looking at honeycomb, we can now check the traces with Links and those trace links will likely be valid ones.

Usage here: https://github.com/getoutreach/clerk/pull/344

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[CDT-203]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[CDT-203]: https://outreach-io.atlassian.net/browse/CDT-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ