### PR TITLE
feat: change queue capacity type to uint

### DIFF
--- a/pkg/queue/example_queue_test.go
+++ b/pkg/queue/example_queue_test.go
@@ -11,10 +11,7 @@ import (
 
 func ExamplePriorityQueue() {
 	// Create priority queue.
-	pq, err := queue.NewPriorityQueue()
-	if err != nil {
-		panic(err)
-	}
+	pq := queue.NewPriorityQueue()
 
 	// Push items.
 	pushItem := func(data interface{}, priority int64) *queue.PriorityQueueItem {

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -60,14 +60,14 @@ import (
 // This section defines default configuration.
 const (
 	// DefaultPriorityQueueCapacity is the default priority queue capacity.
-	DefaultPriorityQueueCapacity = math.MaxInt32
+	DefaultPriorityQueueCapacity = math.MaxUint
 )
 
 // PriorityQueueOption is used to change priority default configuration.
 type PriorityQueueOption func(q *PriorityQueue)
 
 // WithCapacity sets the queue capacity.
-func WithCapacity(v int) PriorityQueueOption {
+func WithCapacity(v uint) PriorityQueueOption {
 	return func(q *PriorityQueue) {
 		q.capacity = v
 	}
@@ -90,7 +90,7 @@ func WithMaxHeap() PriorityQueueOption {
 }
 
 // NewPriorityQueue creates a new priority queue.
-func NewPriorityQueue(opts ...PriorityQueueOption) (*PriorityQueue, error) {
+func NewPriorityQueue(opts ...PriorityQueueOption) *PriorityQueue {
 	q := &PriorityQueue{
 		capacity: DefaultPriorityQueueCapacity,
 		queue:    newPriorityQueueInternal(true),
@@ -98,10 +98,7 @@ func NewPriorityQueue(opts ...PriorityQueueOption) (*PriorityQueue, error) {
 	for _, opt := range opts {
 		opt(q)
 	}
-	if q.capacity <= 0 {
-		return nil, errors.Errorf("invalid capacity: %v", q.capacity)
-	}
-	return q, nil
+	return q
 }
 
 // PriorityQueue implements a priority queue with a heap. By default, min heap is used with a
@@ -109,7 +106,7 @@ func NewPriorityQueue(opts ...PriorityQueueOption) (*PriorityQueue, error) {
 // Queue capacity and heap type can be changed via options.
 type PriorityQueue struct {
 	lock     sync.RWMutex
-	capacity int
+	capacity uint
 	queue    *priorityQueueInternal
 }
 
@@ -119,7 +116,7 @@ type PriorityQueue struct {
 func (q *PriorityQueue) Push(data interface{}, priority int64) (*PriorityQueueItem, error) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
-	if q.queue.Len() >= q.capacity {
+	if uint(q.queue.Len()) >= q.capacity {
 		return nil, errors.New("queue is full")
 	}
 	item := newPriorityQueueItem(data, priority)

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestPriorityQueue_MaxHeap(t *testing.T) {
-	queue, err := NewPriorityQueue(WithMaxHeap())
-	assert.Assert(t, err == nil)
+	queue := NewPriorityQueue(WithMaxHeap())
 	assert.Assert(t, queue.Len() == 0)
 	assert.Assert(t, queue.Peek() == nil)
 	assert.Assert(t, queue.Pop() == nil)
@@ -43,8 +42,7 @@ func TestPriorityQueue_MaxHeap(t *testing.T) {
 }
 
 func TestPriorityQueue_Push_Pop_Peek(t *testing.T) {
-	queue, err := NewPriorityQueue()
-	assert.Assert(t, err == nil)
+	queue := NewPriorityQueue()
 	assert.Assert(t, queue.Len() == 0)
 	assert.Assert(t, queue.Peek() == nil)
 	assert.Assert(t, queue.Pop() == nil)
@@ -76,8 +74,7 @@ func TestPriorityQueue_Push_Pop_Peek(t *testing.T) {
 }
 
 func TestPriorityQueue_Update(t *testing.T) {
-	queue, err := NewPriorityQueue()
-	assert.Assert(t, err == nil)
+	queue := NewPriorityQueue()
 
 	n := 1000
 	repeat := 3
@@ -107,8 +104,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 }
 
 func TestPriorityQueue_Remove(t *testing.T) {
-	queue, err := NewPriorityQueue()
-	assert.Assert(t, err == nil)
+	queue := NewPriorityQueue()
 
 	n := 1000
 	m := n / 2
@@ -165,10 +161,8 @@ func TestPriorityQueue_Remove(t *testing.T) {
 }
 
 func TestPriorityQueue_Contains(t *testing.T) {
-	queue1, err1 := NewPriorityQueue()
-	queue2, err2 := NewPriorityQueue()
-	assert.Assert(t, err1 == nil)
-	assert.Assert(t, err2 == nil)
+	queue1 := NewPriorityQueue()
+	queue2 := NewPriorityQueue()
 
 	testContain := func(items []*PriorityQueueItem, inQueue1, inQueue2 bool) {
 		for _, item := range items {
@@ -201,8 +195,7 @@ func TestPriorityQueue_Contains(t *testing.T) {
 }
 
 func TestPriorityQueue_Clear(t *testing.T) {
-	queue, err := NewPriorityQueue()
-	assert.Assert(t, err == nil)
+	queue := NewPriorityQueue()
 	assert.Assert(t, queue.Len() == 0)
 
 	n := 100
@@ -214,8 +207,7 @@ func TestPriorityQueue_Clear(t *testing.T) {
 }
 
 func TestPriorityQueue_List(t *testing.T) {
-	queue, err := NewPriorityQueue()
-	assert.Assert(t, err == nil)
+	queue := NewPriorityQueue()
 	assert.Assert(t, queue.Len() == 0)
 
 	n := 100
@@ -229,26 +221,9 @@ func TestPriorityQueue_List(t *testing.T) {
 	assert.Assert(t, queue.Len() == n)
 }
 
-func TestPriorityQueue_InvalidSize(t *testing.T) {
-	test := func(size, exp int, hasErr bool) {
-		queue, err := NewPriorityQueue(WithCapacity(size))
-		if hasErr {
-			assert.Assert(t, queue == nil)
-			assert.Assert(t, err != nil)
-			return
-		}
-		assert.Assert(t, err == nil)
-		assert.Assert(t, queue.capacity == exp)
-	}
-	test(-1, DefaultPriorityQueueCapacity, true)
-	test(0, DefaultPriorityQueueCapacity, true)
-	test(1, 1, false)
-}
-
 func TestPriorityQueue_Push_Error(t *testing.T) {
 	size := 3
-	queue, err := NewPriorityQueue(WithCapacity(size))
-	assert.Assert(t, err == nil)
+	queue := NewPriorityQueue(WithCapacity(uint(size)))
 
 	// push
 	n := size * 2
@@ -274,8 +249,7 @@ func TestPriorityQueue_Push_Error(t *testing.T) {
 }
 
 func TestPriorityQueue_Update_Error(t *testing.T) {
-	queue, err := NewPriorityQueue()
-	assert.Assert(t, err == nil)
+	queue := NewPriorityQueue()
 
 	// push
 	item, err := queue.Push(1, 1)
@@ -297,8 +271,7 @@ func TestPriorityQueue_Update_Error(t *testing.T) {
 }
 
 func TestPriorityQueue_Remove_Invalid_Item(t *testing.T) {
-	queue, err := NewPriorityQueue()
-	assert.Assert(t, err == nil)
+	queue := NewPriorityQueue()
 
 	// push
 	item, err := queue.Push(1, 1)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
It does not make sense for a queue capacity to be negative. This PR changes the queue capacity type to be `uint` so that creating a queue is simpler without handling the return error. 


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
