### PR TITLE
fix(cli): small fixes to logic in CLI package(s)

### DIFF
--- a/pkg/cli/updater/resolver/resolver_test.go
+++ b/pkg/cli/updater/resolver/resolver_test.go
@@ -242,7 +242,7 @@ func TestResolve(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var token cfg.SecretData = ""
+			var token cfg.SecretData
 			if tt.o == nil || !tt.o.UseRealResolver {
 				// mock the version resolver
 				oldGetVersions := GetVersions

--- a/pkg/cli/updater/resolver/resolver_test.go
+++ b/pkg/cli/updater/resolver/resolver_test.go
@@ -239,19 +239,6 @@ func TestResolve(t *testing.T) {
 			},
 			want: mustNewVersion(NewVersion("main", true, "abcedfg")),
 		},
-		{
-			name: "should resolve mutable channels properly",
-			o: &opts{
-				UseRealResolver: true,
-			},
-			c: Criteria{
-				URL:           "https://github.com/getoutreach/stencil-clerk",
-				Channel:       "rc",
-				Constraints:   []string{},
-				AllowBranches: true,
-			},
-			want: mustNewVersion(NewVersion("v1.5.1-rc.1", false, "75333f897ab80b845488289c16873b51a4ea67fb")),
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR contains fixes to a few CLI-oriented packages. Primarily it contains a fix for the `resolver` package.

### Resolver Fix

This fix ensures that when consider a branches (with `AllowBranches`) that we do not insert a mutable version for that branch on to the channel. The problem with doing so is that a mutable version is always ranked higher than tags, this is problematic for branches that _only_ release and support tags on the branch (e.g. `rc` vs `unstable`).

We now filter out the mutable insertion after converting references into their channel/version pair, if we have a tag then we remove the latest version (if it's mutable). It will always be the latest version because of the sorting logic (which broke this library) in the previous PR.


### `sshhelper` Fix

This is a small fix to the logic to support read-only ssh-agents (like 1Password) and to allow users to ignore some previously fatal errors that may be "solvable" with their ssh-agent. I needed this for most of our tooling (I use the 1Password ssh-agent)

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3248]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3248]: https://outreach-io.atlassian.net/browse/DT-3248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ