### PR TITLE
fix(cli): try load trace.yaml before overriding

### DIFF
--- a/pkg/cli/bootstrap_test.go
+++ b/pkg/cli/bootstrap_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/getoutreach/gobox/pkg/cfg"
+	"github.com/getoutreach/gobox/pkg/secrets"
+	"github.com/getoutreach/gobox/pkg/trace"
 	"github.com/urfave/cli/v2"
 )
 
@@ -95,4 +98,57 @@ func TestGenerateShellCompletion(t *testing.T) {
 			t.Errorf("expected string %s; got '%s' for lastArg=%s", fixture.expectedOutputRegex, sb.String(), lastArg)
 		}
 	}
+}
+
+func TestOverrideConfigLoaders(t *testing.T) {
+	// we need to override these first so we don't try to load from /run/...
+	t.Run("can load trace.yaml if it doesn't error", func(t *testing.T) {
+		var oldLookup func(context.Context, string) ([]byte, error)
+		oldReader := cfg.DefaultReader()
+
+		t.Cleanup(func() {
+			secrets.SetDevLookup(oldLookup)
+			cfg.SetDefaultReader(oldReader)
+		})
+
+		oldLookup = secrets.SetDevLookup(func(_ context.Context, s string) ([]byte, error) {
+			panic("oh no")
+		})
+
+		cfg.SetDefaultReader(func(s string) ([]byte, error) {
+			return []byte(s), nil
+		})
+
+		overrideConfigLoaders("honeycomb", "dataset", false)
+
+		var target string
+		err := cfg.Load("trace.yaml", &target)
+
+		if err != nil {
+			t.Fatal("expected no error, got", err)
+		}
+		if target != "trace.yaml" {
+			t.Fatal("expected trace.yaml, got", target)
+		}
+	})
+
+	t.Run("if trace.yaml can't be loaded from /var/run/outreach.io; use argument overrides", func(t *testing.T) {
+		// don't need to any set up in tests, should fail just fine 
+		overrideConfigLoaders("honeycomb", "dataset", true)
+
+		var target trace.Config
+		err := cfg.Load("trace.yaml", &target)
+		if err != nil {
+			t.Fatal("expected no error, got", err)
+		}
+
+		secret, err := target.APIKey.Data(context.Background())
+		if err != nil {
+			t.Fatal("expected no error, got", err)
+		}
+
+		if secret != "honeycomb" {
+			t.Fatal("expected honeycomb, got", target.APIKey)
+		}
+	})
 }

--- a/pkg/cli/bootstrap_test.go
+++ b/pkg/cli/bootstrap_test.go
@@ -133,7 +133,7 @@ func TestOverrideConfigLoaders(t *testing.T) {
 	})
 
 	t.Run("if trace.yaml can't be loaded from /var/run/outreach.io; use argument overrides", func(t *testing.T) {
-		// don't need to any set up in tests, should fail just fine 
+		// don't need to any set up in tests, should fail just fine
 		overrideConfigLoaders("honeycomb", "dataset", true)
 
 		var target trace.Config


### PR DESCRIPTION

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

when run in production, the trace.yaml override breaks tracing for
containers that don't use ldflags to set the honeycomb api key.

This simply tries to load trace.yaml before falling back to the CLI's
overrides


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[QSS-1588]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[QSS-1588]: https://outreach-io.atlassian.net/browse/QSS-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ