### PR TITLE
fix: support Run receiving t *testing.T and f of type tester.T

### DIFF
--- a/pkg/tester/tester.go
+++ b/pkg/tester/tester.go
@@ -75,9 +75,20 @@ import (
 // will work with both `go test` and production scenarios (which use
 // tester.T).
 func Run(t T, name string, f interface{}) bool {
+	if _, ok := t.(*testing.T); ok {
+		f = wrapTestFunc(f)
+	}
 	args := []reflect.Value{reflect.ValueOf(name), reflect.ValueOf(f)}
 	results := reflect.ValueOf(t).MethodByName("Run").Call(args)
 	return results[0].Bool()
+}
+
+// wrapTestFunc invokes f with t *testing.T
+func wrapTestFunc(f interface{}) func(t *testing.T) {
+	return func(t *testing.T) {
+		values := []reflect.Value{reflect.ValueOf(t)}
+		reflect.ValueOf(f).Call(values)
+	}
 }
 
 // RunTest executes a single test.


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Allows for Run to receive mismatched types between t and f. We were getting panics in sequencetest when running with t and f being of different types.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
Sorry no Jira ID, just trying to fix up sequencetest's usage of this pkg.


<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
