### PR TITLE
fix(app_domain): add domain to app.Info

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -96,6 +96,16 @@ func info() *Data {
 		environment = env
 	}
 
+	var domain string
+	switch environment {
+	case "development":
+		domain = "outreach-dev.com"
+	case "staging":
+		domain = "outreach-staging.com"
+	default: // production
+		domain = "outreach.io"
+	}
+
 	clusterName := unknown
 	if cn := os.Getenv("MY_CLUSTER"); cn != "" {
 		clusterName = cn
@@ -141,7 +151,8 @@ func info() *Data {
 
 		ServiceID: serviceID,
 
-		Bento: bento,
+		Bento:  bento,
+		Domain: domain,
 	}
 }
 
@@ -178,7 +189,8 @@ type Data struct {
 	// within the `authn` framework.
 	ServiceID string
 
-	Bento string
+	Bento  string
+	Domain string
 }
 
 // MarshalLog marshals the struct for logging

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -16,6 +16,7 @@ func TestAppInfo(t *testing.T) {
 	appInfo := app.Info()
 	assert.Equal(t, appInfo.Name, "appname")
 	assert.Equal(t, appInfo.ServiceID, "appname@outreach.cloud")
+	assert.Equal(t, appInfo.Domain, "outreach.io")
 }
 
 func TestAppInfoRegion(t *testing.T) {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This change adds app domain info to the app.Info() data. We are doing this change to add domain info to the mint tokens which will used (for example) in [authnidentity/userprofile](https://github.com/getoutreach/authnidentity/blob/f58edaa7caede96c88f18000c17ea4f474856c73/internal/handlers/identity.go#L114) to decode the user token in the context. 


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[IATS-754](https://outreach-io.atlassian.net/browse/IATS-754)

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[IATS-754]: https://outreach-io.atlassian.net/browse/IATS-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ