### PR TITLE
fix(test_utils): make it so there's always a env.FakeTestConfig available

### DIFF
--- a/pkg/env/fake_test_config.go
+++ b/pkg/env/fake_test_config.go
@@ -1,0 +1,76 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: Provides configuration reader overriding optionss
+
+package env
+
+import (
+	"fmt"
+	"sync"
+)
+
+// nolint:gochecknoglobals // Why: needs to be overridable
+var overrides = testOverrides{
+	data: make(map[string]interface{}),
+}
+
+// testOverrides is a struct that allows us to override the test config
+type testOverrides struct {
+	data map[string]interface{}
+	mu   sync.Mutex
+}
+
+// add adds a new key to the testOverrides map.
+func (to *testOverrides) add(k string, v interface{}) {
+	to.mu.Lock()
+	defer to.mu.Unlock()
+
+	if _, exists := to.data[k]; exists {
+		// This is not ideal.  We would prefer to return an error. However
+		// the caller function's signature does not support it and we don't
+		// want to incur the backwards-incompatibility of changing it right
+		// now.
+		panic(fmt.Errorf("repeated test override of '%s'", k))
+	}
+
+	to.data[k] = v
+}
+
+// loadTestConfig loads the test config from the testOverrides map.
+func (to *testOverrides) load(k string) (interface{}, bool) {
+	to.mu.Lock()
+	defer to.mu.Unlock()
+
+	// Apparently you cannot pull the bool out of this access implicitly in the return
+	// statement.
+	v, ok := to.data[k]
+
+	return v, ok
+}
+
+// delete removes a key from the testOverrides map.
+func (to *testOverrides) delete(k string) {
+	to.mu.Lock()
+	defer to.mu.Unlock()
+
+	delete(to.data, k)
+}
+
+// FakeTestConfig allows you to fake the test config with a specific value.
+//
+// The provided value is serialized to yaml and so can be structured data.
+//
+// Be extra careful when using this function in parallelized tests - do not
+// use the fName across two tests running in parallel. This will cause the
+// function to potentially panic.
+//
+// TODO[DT-3185]: Related work item to make the safety of this function better
+func FakeTestConfig(fName string, ptr interface{}) func() {
+	// add ensures that it doesn't already exist to prevent two tests running
+	// concurrently colliding on fName.
+	overrides.add(fName, ptr)
+
+	return func() {
+		overrides.delete(fName)
+	}
+}

--- a/pkg/env/readers.go
+++ b/pkg/env/readers.go
@@ -8,59 +8,14 @@
 package env
 
 import (
-	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
-	"sync"
 
 	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/gobox/pkg/cfg"
 	"gopkg.in/yaml.v3"
 )
-
-type testOverrides struct {
-	data map[string]interface{}
-	mu   sync.Mutex
-}
-
-func (to *testOverrides) add(k string, v interface{}) {
-	to.mu.Lock()
-	defer to.mu.Unlock()
-
-	if _, exists := to.data[k]; exists {
-		// This is not ideal.  We would prefer to return an error. However
-		// the caller function's signature does not support it and we don't
-		// want to incur the backwards-incompatibility of changing it right
-		// now.
-		panic(fmt.Errorf("repeated test override of '%s'", k))
-	}
-
-	to.data[k] = v
-}
-
-func (to *testOverrides) load(k string) (interface{}, bool) {
-	to.mu.Lock()
-	defer to.mu.Unlock()
-
-	// Apparently you cannot pull the bool out of this access implicitly in the return
-	// statement.
-	v, ok := to.data[k]
-
-	return v, ok
-}
-
-func (to *testOverrides) delete(k string) {
-	to.mu.Lock()
-	defer to.mu.Unlock()
-
-	delete(to.data, k)
-}
-
-// nolint:gochecknoglobals // Why: needs to be overridable
-var overrides = testOverrides{
-	data: make(map[string]interface{}),
-}
 
 // devReader creates a config reader specific to the dev environment.
 func devReader(fallback cfg.Reader) cfg.Reader { //nolint:deadcode,unused // Why: only used with certain build tags
@@ -106,23 +61,4 @@ func testReader(fallback cfg.Reader, overrider *testOverrides) cfg.Reader {
 		}
 		return fallback(fileName)
 	})
-}
-
-// FakeTestConfig allows you to fake the test config with a specific value.
-//
-// The provided value is serialized to yaml and so can be structured data.
-//
-// Be extra careful when using this function in parallelized tests - do not
-// use the fName across two tests running in parallel. This will cause the
-// function to potentially panic.
-//
-// TODO[DT-3185]: Related work item to make the safety of this function better
-func FakeTestConfig(fName string, ptr interface{}) func() {
-	// add ensures that it doesn't already exist to prevent two tests running
-	// concurrently colliding on fName.
-	overrides.add(fName, ptr)
-
-	return func() {
-		overrides.delete(fName)
-	}
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Ensures that no matter the build constraints, there is always a env.FakeTestConfig

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[QSS-1750]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[QSS-1750]: https://outreach-io.atlassian.net/browse/QSS-1750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ