### PR TITLE
feat: Adding "module" field to logs with module of actual logger

### DIFF
--- a/pkg/callerinfo/callerinfo.go
+++ b/pkg/callerinfo/callerinfo.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: Provides the ability to discover the module+function who is calling you.
+
+// Package callerinfo provides the GetCallerFunction to get the name of the module and function
+// that has called you.
+package callerinfo
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var moduleLookupByPC = make(map[uintptr]string)
+
+// Returns the name of the function, including module if applicable, that called GetCallerFunction.
+// skipFrames determines how many frames above that to skip.  If you want to know who is calling your
+// function, you would pass in skipFrames of 1.  skipFrames of 0 will return yourself.
+func GetCallerFunction(skipFrames uint16) (string, error) {
+	// We only care about the one stack frame above the caller, so skip at least two:
+	// 1. runtime.Callers
+	// 2. GetCallerModule
+	pc := make([]uintptr, 1)
+	skipTotal := 2 + int(skipFrames)
+	num := runtime.Callers(skipTotal, pc)
+	if num == 0 {
+		return "", fmt.Errorf("no frames returned from skip %d", skipTotal)
+	}
+
+	if mod, valid := moduleLookupByPC[pc[0]]; valid {
+		// Found it in the cache
+		return mod, nil
+	}
+
+	// Not cached -- have to do the slow lookup
+	frames := runtime.CallersFrames(pc)
+	frame, _ := frames.Next()
+
+	// Cache for later
+	moduleLookupByPC[pc[0]] = frame.Function
+	return frame.Function, nil
+}

--- a/pkg/callerinfo/callerinfo_test.go
+++ b/pkg/callerinfo/callerinfo_test.go
@@ -1,0 +1,41 @@
+package callerinfo
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_Callers(t *testing.T) {
+	assert.Equal(t, len(moduleLookupByPC), 0)
+
+	caller, err := GetCallerFunction(0)
+	assert.NilError(t, err)
+	assert.Equal(t, caller, "github.com/getoutreach/gobox/pkg/callerinfo.Test_Callers")
+
+	assert.Equal(t, len(moduleLookupByPC), 1)
+
+	caller2, err2 := testhelper1()
+	assert.NilError(t, err2)
+	assert.Equal(t, caller2, "github.com/getoutreach/gobox/pkg/callerinfo.Test_Callers")
+
+	// Same result, but different call site, so will be a new PC->Function lookup
+	assert.Equal(t, len(moduleLookupByPC), 2)
+
+	// This call will not be cached
+	_, _ = testhelper2()
+	assert.Equal(t, len(moduleLookupByPC), 3)
+	// This call will be cached
+	_, _ = testhelper2()
+	assert.Equal(t, len(moduleLookupByPC), 3)
+}
+
+//go:noinline
+func testhelper1() (string, error) {
+	return GetCallerFunction(1)
+}
+
+//go:noinline
+func testhelper2() (string, error) {
+	return GetCallerFunction(0)
+}

--- a/pkg/callerinfo/callerinfo_test.go
+++ b/pkg/callerinfo/callerinfo_test.go
@@ -1,6 +1,7 @@
 package callerinfo
 
 import (
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -9,15 +10,20 @@ import (
 func Test_Callers(t *testing.T) {
 	assert.Equal(t, len(moduleLookupByPC), 0)
 
-	caller, err := GetCallerFunction(0)
+	ci, err := GetCallerInfo(0)
 	assert.NilError(t, err)
-	assert.Equal(t, caller, "github.com/getoutreach/gobox/pkg/callerinfo.Test_Callers")
+	assert.Equal(t, ci.Function, "github.com/getoutreach/gobox/pkg/callerinfo.Test_Callers")
+	assert.Check(t, strings.HasSuffix(ci.File, "callerinfo_test.go"))
+	assert.Check(t, ci.LineNum > 0)
+	assert.Equal(t, ci.Module, "github.com/getoutreach/gobox")
+	// Until https://github.com/golang/go/issues/33976 is fixed, module info is not available in unit tests >_<
+	// assert.Check(t, ci.ModuleVersion != "")
 
 	assert.Equal(t, len(moduleLookupByPC), 1)
 
-	caller2, err2 := testhelper1()
+	ci2, err2 := testhelper1()
 	assert.NilError(t, err2)
-	assert.Equal(t, caller2, "github.com/getoutreach/gobox/pkg/callerinfo.Test_Callers")
+	assert.Equal(t, ci2.Function, "github.com/getoutreach/gobox/pkg/callerinfo.Test_Callers")
 
 	// Same result, but different call site, so will be a new PC->Function lookup
 	assert.Equal(t, len(moduleLookupByPC), 2)
@@ -31,11 +37,11 @@ func Test_Callers(t *testing.T) {
 }
 
 //go:noinline
-func testhelper1() (string, error) {
-	return GetCallerFunction(1)
+func testhelper1() (CallerInfo, error) {
+	return GetCallerInfo(1)
 }
 
 //go:noinline
-func testhelper2() (string, error) {
-	return GetCallerFunction(0)
+func testhelper2() (CallerInfo, error) {
+	return GetCallerInfo(0)
 }

--- a/pkg/log/adapters/adapters_test.go
+++ b/pkg/log/adapters/adapters_test.go
@@ -43,10 +43,10 @@ func ExampleNewLogrLogger() {
 
 	//nolint:lll // Why: testing output
 	// Output:
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","level":"INFO","message":"true","source":"getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, world","source":"getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"level":"INFO","message":"info!!","source":"getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"error.error":"bad thing","error.kind":"error","error.message":"bad thing","level":"ERROR","message":"end of the world!","source":"getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","level":"INFO","message":"true","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, world","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"level":"INFO","message":"info!!","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"error.error":"bad thing","error.kind":"error","error.message":"bad thing","level":"ERROR","message":"end of the world!","source":"github.com/getoutreach/gobox"}
 }
 
 func ExampleNewRetryableHTTPLogger() {
@@ -64,8 +64,8 @@ func ExampleNewRetryableHTTPLogger() {
 
 	//nolint:lll // Why: testing output
 	// Output:
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, info","source":"getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"DEBUG","message":"hello, debug","source":"getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"ERROR","message":"hello, error","source":"getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"WARN","message":"hello, warn","source":"getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, info","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"DEBUG","message":"hello, debug","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"ERROR","message":"hello, error","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"WARN","message":"hello, warn","source":"github.com/getoutreach/gobox"}
 }

--- a/pkg/log/adapters/adapters_test.go
+++ b/pkg/log/adapters/adapters_test.go
@@ -43,10 +43,10 @@ func ExampleNewLogrLogger() {
 
 	//nolint:lll // Why: testing output
 	// Output:
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","level":"INFO","message":"true","source":"gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, world","source":"gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"level":"INFO","message":"info!!","source":"gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"error.error":"bad thing","error.kind":"error","error.message":"bad thing","level":"ERROR","message":"end of the world!","source":"gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","level":"INFO","message":"true","source":"getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, world","source":"getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"level":"INFO","message":"info!!","source":"getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"error.error":"bad thing","error.kind":"error","error.message":"bad thing","level":"ERROR","message":"end of the world!","source":"getoutreach/gobox"}
 }
 
 func ExampleNewRetryableHTTPLogger() {
@@ -64,8 +64,8 @@ func ExampleNewRetryableHTTPLogger() {
 
 	//nolint:lll // Why: testing output
 	// Output:
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, info","source":"gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"DEBUG","message":"hello, debug","source":"gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"ERROR","message":"hello, error","source":"gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"WARN","message":"hello, warn","source":"gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, info","source":"getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"DEBUG","message":"hello, debug","source":"getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"ERROR","message":"hello, error","source":"getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"WARN","message":"hello, warn","source":"getoutreach/gobox"}
 }

--- a/pkg/log/adapters/adapters_test.go
+++ b/pkg/log/adapters/adapters_test.go
@@ -43,10 +43,10 @@ func ExampleNewLogrLogger() {
 
 	//nolint:lll // Why: testing output
 	// Output:
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","level":"INFO","message":"true"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, world"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"level":"INFO","message":"info!!"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"error.error":"bad thing","error.kind":"error","error.message":"bad thing","level":"ERROR","message":"end of the world!"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","level":"INFO","message":"true","source":"gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, world","source":"gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"level":"INFO","message":"info!!","source":"gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"error.error":"bad thing","error.kind":"error","error.message":"bad thing","level":"ERROR","message":"end of the world!","source":"gobox"}
 }
 
 func ExampleNewRetryableHTTPLogger() {
@@ -64,8 +64,8 @@ func ExampleNewRetryableHTTPLogger() {
 
 	//nolint:lll // Why: testing output
 	// Output:
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, info"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"DEBUG","message":"hello, debug"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"ERROR","message":"hello, error"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"WARN","message":"hello, warn"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, info","source":"gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"DEBUG","message":"hello, debug","source":"gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"ERROR","message":"hello, error","source":"gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"WARN","message":"hello, warn","source":"gobox"}
 }

--- a/pkg/log/adapters/adapters_test.go
+++ b/pkg/log/adapters/adapters_test.go
@@ -43,10 +43,10 @@ func ExampleNewLogrLogger() {
 
 	//nolint:lll // Why: testing output
 	// Output:
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","level":"INFO","message":"true","source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, world","source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"level":"INFO","message":"info!!","source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"error.error":"bad thing","error.kind":"error","error.message":"bad thing","level":"ERROR","message":"end of the world!","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","level":"INFO","message":"true","module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, world","module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"level":"INFO","message":"info!!","module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","app.version":"testing","b":"hello, world!","c":1,"error.error":"bad thing","error.kind":"error","error.message":"bad thing","level":"ERROR","message":"end of the world!","module":"github.com/getoutreach/gobox"}
 }
 
 func ExampleNewRetryableHTTPLogger() {
@@ -64,8 +64,8 @@ func ExampleNewRetryableHTTPLogger() {
 
 	//nolint:lll // Why: testing output
 	// Output:
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, info","source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"DEBUG","message":"hello, debug","source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"ERROR","message":"hello, error","source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"WARN","message":"hello, warn","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"INFO","message":"hello, info","module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"DEBUG","message":"hello, debug","module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"ERROR","message":"hello, error","module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2021-12-21T14:19:20.0424249-08:00","a":1,"app.version":"testing","level":"WARN","message":"hello, warn","module":"github.com/getoutreach/gobox"}
 }

--- a/pkg/log/caller_test.go
+++ b/pkg/log/caller_test.go
@@ -28,6 +28,7 @@ func (callerSuite) TestCaller(t *testing.T) {
 		"caller":      "gobox/pkg/log/caller_test.go:23",
 		"level":       "INFO",
 		"message":     "caller test",
+		"source":      "gobox",
 	}}
 
 	assert.DeepEqual(t, expected, logs.Entries(), differs.Custom())

--- a/pkg/log/caller_test.go
+++ b/pkg/log/caller_test.go
@@ -28,7 +28,7 @@ func (callerSuite) TestCaller(t *testing.T) {
 		"caller":      "gobox/pkg/log/caller_test.go:23",
 		"level":       "INFO",
 		"message":     "caller test",
-		"source":      "github.com/getoutreach/gobox",
+		"module":      "github.com/getoutreach/gobox",
 	}}
 
 	assert.DeepEqual(t, expected, logs.Entries(), differs.Custom())

--- a/pkg/log/caller_test.go
+++ b/pkg/log/caller_test.go
@@ -28,7 +28,7 @@ func (callerSuite) TestCaller(t *testing.T) {
 		"caller":      "gobox/pkg/log/caller_test.go:23",
 		"level":       "INFO",
 		"message":     "caller test",
-		"source":      "getoutreach/gobox",
+		"source":      "github.com/getoutreach/gobox",
 	}}
 
 	assert.DeepEqual(t, expected, logs.Entries(), differs.Custom())

--- a/pkg/log/caller_test.go
+++ b/pkg/log/caller_test.go
@@ -28,7 +28,7 @@ func (callerSuite) TestCaller(t *testing.T) {
 		"caller":      "gobox/pkg/log/caller_test.go:23",
 		"level":       "INFO",
 		"message":     "caller test",
-		"source":      "gobox",
+		"source":      "getoutreach/gobox",
 	}}
 
 	assert.DeepEqual(t, expected, logs.Entries(), differs.Custom())

--- a/pkg/log/fatal_test.go
+++ b/pkg/log/fatal_test.go
@@ -37,7 +37,7 @@ func (fatalSuite) TestFatal(t *testing.T) {
 		"error.stack": differs.StackLike("goroutine\nruntime/debug.Stack\ndebug/stack.go\nlog.generateFatalFields\nlog/log.go\nlog.format\nlog/log.go\nlog.Error\nlog/log.go\nlog_test.fatalSuite.TestFatal"),
 		"level":       "FATAL",
 		"message":     "example",
-		"source":      "getoutreach/gobox",
+		"source":      "github.com/getoutreach/gobox",
 	}}
 
 	if diff := cmp.Diff(want, got, differs.Custom()); diff != "" {
@@ -70,7 +70,7 @@ func (fatalSuite) TestFatalWithError(t *testing.T) {
 		"error.cause.message": "my error",
 		"message":             "example",
 		"level":               "FATAL",
-		"source":              "getoutreach/gobox",
+		"source":              "github.com/getoutreach/gobox",
 	}}
 
 	if diff := cmp.Diff(want, got, differs.Custom()); diff != "" {

--- a/pkg/log/fatal_test.go
+++ b/pkg/log/fatal_test.go
@@ -37,7 +37,7 @@ func (fatalSuite) TestFatal(t *testing.T) {
 		"error.stack": differs.StackLike("goroutine\nruntime/debug.Stack\ndebug/stack.go\nlog.generateFatalFields\nlog/log.go\nlog.format\nlog/log.go\nlog.Error\nlog/log.go\nlog_test.fatalSuite.TestFatal"),
 		"level":       "FATAL",
 		"message":     "example",
-		"source":      "github.com/getoutreach/gobox",
+		"module":      "github.com/getoutreach/gobox",
 	}}
 
 	if diff := cmp.Diff(want, got, differs.Custom()); diff != "" {
@@ -70,7 +70,7 @@ func (fatalSuite) TestFatalWithError(t *testing.T) {
 		"error.cause.message": "my error",
 		"message":             "example",
 		"level":               "FATAL",
-		"source":              "github.com/getoutreach/gobox",
+		"module":              "github.com/getoutreach/gobox",
 	}}
 
 	if diff := cmp.Diff(want, got, differs.Custom()); diff != "" {

--- a/pkg/log/fatal_test.go
+++ b/pkg/log/fatal_test.go
@@ -37,7 +37,7 @@ func (fatalSuite) TestFatal(t *testing.T) {
 		"error.stack": differs.StackLike("goroutine\nruntime/debug.Stack\ndebug/stack.go\nlog.generateFatalFields\nlog/log.go\nlog.format\nlog/log.go\nlog.Error\nlog/log.go\nlog_test.fatalSuite.TestFatal"),
 		"level":       "FATAL",
 		"message":     "example",
-		"source":      "gobox",
+		"source":      "getoutreach/gobox",
 	}}
 
 	if diff := cmp.Diff(want, got, differs.Custom()); diff != "" {
@@ -70,7 +70,7 @@ func (fatalSuite) TestFatalWithError(t *testing.T) {
 		"error.cause.message": "my error",
 		"message":             "example",
 		"level":               "FATAL",
-		"source":              "gobox",
+		"source":              "getoutreach/gobox",
 	}}
 
 	if diff := cmp.Diff(want, got, differs.Custom()); diff != "" {

--- a/pkg/log/fatal_test.go
+++ b/pkg/log/fatal_test.go
@@ -37,6 +37,7 @@ func (fatalSuite) TestFatal(t *testing.T) {
 		"error.stack": differs.StackLike("goroutine\nruntime/debug.Stack\ndebug/stack.go\nlog.generateFatalFields\nlog/log.go\nlog.format\nlog/log.go\nlog.Error\nlog/log.go\nlog_test.fatalSuite.TestFatal"),
 		"level":       "FATAL",
 		"message":     "example",
+		"source":      "gobox",
 	}}
 
 	if diff := cmp.Diff(want, got, differs.Custom()); diff != "" {
@@ -69,6 +70,7 @@ func (fatalSuite) TestFatalWithError(t *testing.T) {
 		"error.cause.message": "my error",
 		"message":             "example",
 		"level":               "FATAL",
+		"source":              "gobox",
 	}}
 
 	if diff := cmp.Diff(want, got, differs.Custom()); diff != "" {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -166,7 +166,7 @@ func format(msg, level string, ts time.Time, appInfo Marshaler, mm Many) string 
 }
 
 func addSource(entry F) {
-	// Attempt to map the caller of the log function into the "source" field for identifying if a service or a module
+	// Attempt to map the caller of the log function into the "module" field for identifying if a service or a module
 	// that the service is using is sending logs (costing money).
 	// Skip 3 levels:
 	// 1. addSource
@@ -175,11 +175,11 @@ func addSource(entry F) {
 	ci, err := callerinfo.GetCallerInfo(3)
 	switch {
 	case err != nil:
-		entry["source"] = "error"
+		entry["module"] = "error"
 	case ci.Module != "":
-		entry["source"] = ci.Module
+		entry["module"] = ci.Module
 		if ci.ModuleVersion != "" {
-			entry["sourcever"] = ci.ModuleVersion
+			entry["modulever"] = ci.ModuleVersion
 		}
 	}
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -157,12 +157,18 @@ func format(msg, level string, ts time.Time, appInfo Marshaler, mm Many) string 
 	switch {
 	case err != nil:
 		entry["source"] = "error"
-	case strings.HasPrefix(caller, "github.com/getoutreach"):
+	case strings.HasPrefix(caller, "github.com/"):
 		// Example response: github.com/getoutreach/gobox/pkg/callerinfo.Test_Callers
 		splits := strings.Split(caller, "/")
-		// We're going for extracting "gobox" in the above example
-		entry["source"] = splits[2]
+		// We're going for extracting "getoutreach/gobox" in the above example
+		if len(splits) >= 3 {
+			entry["source"] = splits[1] + "/" + splits[2]
+		} else {
+			entry["source"] = splits[1]
+		}
 	case strings.HasPrefix(caller, "main"):
+		// Main entry point for the app shows up as "main.[funcname]", so just use the app name since we unfortunately
+		// don't have a full package name
 		entry["source"] = app.Info().Name
 	default:
 		entry["source"] = "unknown:" + caller

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -23,9 +23,9 @@ func Example() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myField":42,"source":"getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","myField":42,"source":"getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","myField":42,"source":"getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myField":42,"source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","myField":42,"source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","myField":42,"source":"github.com/getoutreach/gobox"}
 }
 
 func Example_with_custom_event() {
@@ -37,7 +37,7 @@ func Example_with_custom_event() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myevent_field":"boo","source":"getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myevent_field":"boo","source":"github.com/getoutreach/gobox"}
 }
 
 func ExampleDebug_with_error() {
@@ -49,8 +49,8 @@ func ExampleDebug_with_error() {
 
 	printEntries(logs.Entries())
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","myField":42,"source":"getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","myField":42,"source":"getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","myField":42,"source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","myField":42,"source":"github.com/getoutreach/gobox"}
 }
 
 func Example_with_nested_custom_event() {
@@ -68,7 +68,7 @@ func Example_with_nested_custom_event() {
 
 	//nolint:lll // Why: Output
 	// Output:
-	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","rootfield":"value","source":"getoutreach/gobox"}
+	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","rootfield":"value","source":"github.com/getoutreach/gobox"}
 }
 
 func ExampleDebug_without_error() {
@@ -84,8 +84,8 @@ func ExampleDebug_without_error() {
 	printEntries(entries[:len(entries)-1])
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","myField":42,"source":"getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","myField":42,"source":"getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","myField":42,"source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","myField":42,"source":"github.com/getoutreach/gobox"}
 }
 
 func Example_appName() {
@@ -100,7 +100,7 @@ func Example_appName() {
 	printEntries(logs.Entries())
 	//nolint:lll // Why: Output
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","myField":42,"service_name":"app_name","source":"getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","myField":42,"service_name":"app_name","source":"github.com/getoutreach/gobox"}
 }
 
 func printEntries(entries []log.F) {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -23,9 +23,9 @@ func Example() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myField":42,"module":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","myField":42,"module":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","myField":42,"module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","module":"github.com/getoutreach/gobox","myField":42}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","module":"github.com/getoutreach/gobox","myField":42}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","module":"github.com/getoutreach/gobox","myField":42}
 }
 
 func Example_with_custom_event() {
@@ -37,7 +37,7 @@ func Example_with_custom_event() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myevent_field":"boo","module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","module":"github.com/getoutreach/gobox","myevent_field":"boo"}
 }
 
 func ExampleDebug_with_error() {
@@ -49,8 +49,8 @@ func ExampleDebug_with_error() {
 
 	printEntries(logs.Entries())
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","myField":42,"module":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","myField":42,"module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","module":"github.com/getoutreach/gobox","myField":42}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","module":"github.com/getoutreach/gobox","myField":42}
 }
 
 func Example_with_nested_custom_event() {
@@ -68,7 +68,7 @@ func Example_with_nested_custom_event() {
 
 	//nolint:lll // Why: Output
 	// Output:
-	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","rootfield":"value","module":"github.com/getoutreach/gobox"}
+	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","module":"github.com/getoutreach/gobox","rootfield":"value"}
 }
 
 func ExampleDebug_without_error() {
@@ -84,8 +84,8 @@ func ExampleDebug_without_error() {
 	printEntries(entries[:len(entries)-1])
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","myField":42,"module":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","myField":42,"module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","module":"github.com/getoutreach/gobox","myField":42}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","module":"github.com/getoutreach/gobox","myField":42}
 }
 
 func Example_appName() {
@@ -100,7 +100,7 @@ func Example_appName() {
 	printEntries(logs.Entries())
 	//nolint:lll // Why: Output
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","myField":42,"service_name":"app_name","module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","module":"github.com/getoutreach/gobox","myField":42,"service_name":"app_name"}
 }
 
 func printEntries(entries []log.F) {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -23,9 +23,9 @@ func Example() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myField":42,"source":"gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","myField":42,"source":"gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","myField":42,"source":"gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myField":42,"source":"getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","myField":42,"source":"getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","myField":42,"source":"getoutreach/gobox"}
 }
 
 func Example_with_custom_event() {
@@ -37,7 +37,7 @@ func Example_with_custom_event() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myevent_field":"boo","source":"gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myevent_field":"boo","source":"getoutreach/gobox"}
 }
 
 func ExampleDebug_with_error() {
@@ -49,8 +49,8 @@ func ExampleDebug_with_error() {
 
 	printEntries(logs.Entries())
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","myField":42,"source":"gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","myField":42,"source":"gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","myField":42,"source":"getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","myField":42,"source":"getoutreach/gobox"}
 }
 
 func Example_with_nested_custom_event() {
@@ -68,7 +68,7 @@ func Example_with_nested_custom_event() {
 
 	//nolint:lll // Why: Output
 	// Output:
-	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","rootfield":"value","source":"gobox"}
+	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","rootfield":"value","source":"getoutreach/gobox"}
 }
 
 func ExampleDebug_without_error() {
@@ -84,8 +84,8 @@ func ExampleDebug_without_error() {
 	printEntries(entries[:len(entries)-1])
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","myField":42,"source":"gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","myField":42,"source":"gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","myField":42,"source":"getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","myField":42,"source":"getoutreach/gobox"}
 }
 
 func Example_appName() {
@@ -100,7 +100,7 @@ func Example_appName() {
 	printEntries(logs.Entries())
 	//nolint:lll // Why: Output
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","myField":42,"service_name":"app_name","source":"gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","myField":42,"service_name":"app_name","source":"getoutreach/gobox"}
 }
 
 func printEntries(entries []log.F) {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -23,9 +23,9 @@ func Example() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myField":42,"source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","myField":42,"source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","myField":42,"source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myField":42,"module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","myField":42,"module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","myField":42,"module":"github.com/getoutreach/gobox"}
 }
 
 func Example_with_custom_event() {
@@ -37,7 +37,7 @@ func Example_with_custom_event() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myevent_field":"boo","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myevent_field":"boo","module":"github.com/getoutreach/gobox"}
 }
 
 func ExampleDebug_with_error() {
@@ -49,8 +49,8 @@ func ExampleDebug_with_error() {
 
 	printEntries(logs.Entries())
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","myField":42,"source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","myField":42,"source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","myField":42,"module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","myField":42,"module":"github.com/getoutreach/gobox"}
 }
 
 func Example_with_nested_custom_event() {
@@ -68,7 +68,7 @@ func Example_with_nested_custom_event() {
 
 	//nolint:lll // Why: Output
 	// Output:
-	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","rootfield":"value","source":"github.com/getoutreach/gobox"}
+	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","rootfield":"value","module":"github.com/getoutreach/gobox"}
 }
 
 func ExampleDebug_without_error() {
@@ -84,8 +84,8 @@ func ExampleDebug_without_error() {
 	printEntries(entries[:len(entries)-1])
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","myField":42,"source":"github.com/getoutreach/gobox"}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","myField":42,"source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","myField":42,"module":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","myField":42,"module":"github.com/getoutreach/gobox"}
 }
 
 func Example_appName() {
@@ -100,7 +100,7 @@ func Example_appName() {
 	printEntries(logs.Entries())
 	//nolint:lll // Why: Output
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","myField":42,"service_name":"app_name","source":"github.com/getoutreach/gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","myField":42,"service_name":"app_name","module":"github.com/getoutreach/gobox"}
 }
 
 func printEntries(entries []log.F) {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -23,9 +23,9 @@ func Example() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myField":42}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","myField":42}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","myField":42}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myField":42,"source":"gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"WARN","message":"example","myField":42,"source":"gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"example","myField":42,"source":"gobox"}
 }
 
 func Example_with_custom_event() {
@@ -37,7 +37,7 @@ func Example_with_custom_event() {
 	printEntries(logs.Entries())
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myevent_field":"boo"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"example","myevent_field":"boo","source":"gobox"}
 }
 
 func ExampleDebug_with_error() {
@@ -49,8 +49,8 @@ func ExampleDebug_with_error() {
 
 	printEntries(logs.Entries())
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","myField":42}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","myField":42}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"msg1","myField":42,"source":"gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"ERROR","message":"msg2","myField":42,"source":"gobox"}
 }
 
 func Example_with_nested_custom_event() {
@@ -68,7 +68,7 @@ func Example_with_nested_custom_event() {
 
 	//nolint:lll // Why: Output
 	// Output:
-	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","rootfield":"value"}
+	//{"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","error.cause":" error","error.data.myevent_field":"boo","level":"INFO","message":"example","rootfield":"value","source":"gobox"}
 }
 
 func ExampleDebug_without_error() {
@@ -84,8 +84,8 @@ func ExampleDebug_without_error() {
 	printEntries(entries[:len(entries)-1])
 
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","myField":42}
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","myField":42}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"INFO","message":"debug","myField":42,"source":"gobox"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.version":"testing","level":"DEBUG","message":"debug","myField":42,"source":"gobox"}
 }
 
 func Example_appName() {
@@ -100,7 +100,7 @@ func Example_appName() {
 	printEntries(logs.Entries())
 	//nolint:lll // Why: Output
 	// Output:
-	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","myField":42,"service_name":"app_name"}
+	// {"@timestamp":"2019-09-05T14:27:40Z","app.name":"app_name","app.version":"testing","level":"INFO","message":"orgful","myField":42,"service_name":"app_name","source":"gobox"}
 }
 
 func printEntries(entries []log.F) {

--- a/pkg/log/with_test.go
+++ b/pkg/log/with_test.go
@@ -34,6 +34,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "INFO",
 			"message":     "Info message",
 			"some":        "thing",
+			"source":      "gobox",
 			"with":        "hey",
 		},
 		{
@@ -42,6 +43,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "WARN",
 			"message":     "Warn message",
 			"some":        "thing",
+			"source":      "gobox",
 			"with":        "hey",
 		},
 		{
@@ -50,6 +52,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "DEBUG",
 			"message":     "Debug message",
 			"some":        "thing",
+			"source":      "gobox",
 			"with":        "hey",
 		},
 		{
@@ -58,6 +61,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "ERROR",
 			"message":     "Warn message",
 			"some":        "thing",
+			"source":      "gobox",
 			"with":        "hey",
 		},
 	}

--- a/pkg/log/with_test.go
+++ b/pkg/log/with_test.go
@@ -34,7 +34,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "INFO",
 			"message":     "Info message",
 			"some":        "thing",
-			"source":      "github.com/getoutreach/gobox",
+			"module":      "github.com/getoutreach/gobox",
 			"with":        "hey",
 		},
 		{
@@ -43,7 +43,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "WARN",
 			"message":     "Warn message",
 			"some":        "thing",
-			"source":      "github.com/getoutreach/gobox",
+			"module":      "github.com/getoutreach/gobox",
 			"with":        "hey",
 		},
 		{
@@ -52,7 +52,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "DEBUG",
 			"message":     "Debug message",
 			"some":        "thing",
-			"source":      "github.com/getoutreach/gobox",
+			"module":      "github.com/getoutreach/gobox",
 			"with":        "hey",
 		},
 		{
@@ -61,7 +61,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "ERROR",
 			"message":     "Warn message",
 			"some":        "thing",
-			"source":      "github.com/getoutreach/gobox",
+			"module":      "github.com/getoutreach/gobox",
 			"with":        "hey",
 		},
 	}

--- a/pkg/log/with_test.go
+++ b/pkg/log/with_test.go
@@ -34,7 +34,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "INFO",
 			"message":     "Info message",
 			"some":        "thing",
-			"source":      "gobox",
+			"source":      "getoutreach/gobox",
 			"with":        "hey",
 		},
 		{
@@ -43,7 +43,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "WARN",
 			"message":     "Warn message",
 			"some":        "thing",
-			"source":      "gobox",
+			"source":      "getoutreach/gobox",
 			"with":        "hey",
 		},
 		{
@@ -52,7 +52,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "DEBUG",
 			"message":     "Debug message",
 			"some":        "thing",
-			"source":      "gobox",
+			"source":      "getoutreach/gobox",
 			"with":        "hey",
 		},
 		{
@@ -61,7 +61,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "ERROR",
 			"message":     "Warn message",
 			"some":        "thing",
-			"source":      "gobox",
+			"source":      "getoutreach/gobox",
 			"with":        "hey",
 		},
 	}

--- a/pkg/log/with_test.go
+++ b/pkg/log/with_test.go
@@ -34,7 +34,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "INFO",
 			"message":     "Info message",
 			"some":        "thing",
-			"source":      "getoutreach/gobox",
+			"source":      "github.com/getoutreach/gobox",
 			"with":        "hey",
 		},
 		{
@@ -43,7 +43,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "WARN",
 			"message":     "Warn message",
 			"some":        "thing",
-			"source":      "getoutreach/gobox",
+			"source":      "github.com/getoutreach/gobox",
 			"with":        "hey",
 		},
 		{
@@ -52,7 +52,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "DEBUG",
 			"message":     "Debug message",
 			"some":        "thing",
-			"source":      "getoutreach/gobox",
+			"source":      "github.com/getoutreach/gobox",
 			"with":        "hey",
 		},
 		{
@@ -61,7 +61,7 @@ func (withSuite) TestWith(t *testing.T) {
 			"level":       "ERROR",
 			"message":     "Warn message",
 			"some":        "thing",
-			"source":      "getoutreach/gobox",
+			"source":      "github.com/getoutreach/gobox",
 			"with":        "hey",
 		},
 	}


### PR DESCRIPTION
Walking stack with caching stack frame lookups to find out who is calling the logger and adding it to all formatted logs.  Intent is to be able to filter out what application is the actual source of logs for filtering/cost attribution.