### PR TITLE
fix(shuffler): deprecate shuffler package, allow build when or_e2e is set

### DIFF
--- a/pkg/shuffler/doc.go
+++ b/pkg/shuffler/doc.go
@@ -46,4 +46,8 @@
 //	func TestCapacitorSuite(t *testing.T) {
 //	    shuffler.Run(t, new(YourTestSuite))
 //	}
+//
+// Deprecated: Test shuffling is supported of the box in Go 1.17 and later
+// via the -shuffle flag. Use native go test functionality instead of this
+// package.
 package shuffler

--- a/pkg/shuffler/doc.go
+++ b/pkg/shuffler/doc.go
@@ -47,7 +47,7 @@
 //	    shuffler.Run(t, new(YourTestSuite))
 //	}
 //
-// Deprecated: Test shuffling is supported of the box in Go 1.17 and later
+// Deprecated: Test shuffling is supported out of the box in Go 1.17 and later
 // via the -shuffle flag. Use native go test functionality instead of this
 // package.
 package shuffler

--- a/pkg/shuffler/suite.go
+++ b/pkg/shuffler/suite.go
@@ -1,5 +1,3 @@
-//go:build !or_e2e
-
 // Copyright 2022 Outreach Corporation. All Rights Reserved.
 
 // Description: Provides helpers for creating a shuffler test suite
@@ -22,6 +20,10 @@ import (
 // nolint:gochecknoglobals // Why: flag used in multiple places
 var shuffleSeed = flag.Int64("shuffler.seed", 0, "Specify a seed for the randomization of test methods")
 
+// Type TestSuite is an interface that all test suites must implement
+//
+// Deprecated: TestSuites are no longer required. See Run for
+// more information.
 type TestSuite interface{}
 
 // failOnPanic exists to ensure we capture the specific test context
@@ -38,6 +40,10 @@ func failOnPanic(t *testing.T, finished *bool) {
 
 // Run takes test suites and runs all the exported Test* methods in
 // random order.
+//
+// Deprecated: Go now has native support for shuffling tests and is
+// enabled out-of-the-box thanks to the -shuffle flag. Use native
+// go test functionality instead of this package.
 func Run(t *testing.T, suites ...TestSuite) {
 	var finished bool
 	defer failOnPanic(t, &finished)

--- a/pkg/shuffler/suite_test.go
+++ b/pkg/shuffler/suite_test.go
@@ -1,5 +1,3 @@
-//go:build !or_e2e
-
 package shuffler
 
 import (


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Deprecates the `shuffler` package in favor of native go testing (shuffling is supported OOTB since 1.17 and we've enabled it). Also removes `!or_e2e` constraint due to this causing compilation issues in some packages.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers


[**Internal Slack Thread**](https://outreach-hq.slack.com/archives/C03RV4VGAE7/p1677791110515529)

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
