### PR TITLE
fix(trace): usage revealed a panic

### DIFF
--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -226,9 +226,6 @@ func (t *otelTracer) end(ctx context.Context) {
 func (t *otelTracer) addInfo(ctx context.Context, args ...log.Marshaler) {
 	if span := trace.SpanFromContext(ctx); span != nil {
 		for _, arg := range args {
-			if arg == nil {
-				continue
-			}
 			kvs := marshalToKeyValue(arg)
 			span.SetAttributes(kvs...)
 

--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -226,16 +226,27 @@ func (t *otelTracer) end(ctx context.Context) {
 func (t *otelTracer) addInfo(ctx context.Context, args ...log.Marshaler) {
 	if span := trace.SpanFromContext(ctx); span != nil {
 		for _, arg := range args {
+			if arg == nil {
+				continue
+			}
 			kvs := marshalToKeyValue(arg)
 			span.SetAttributes(kvs...)
 
 			switch v := arg.(type) {
 			case *events.ErrorInfo:
+				if v == nil {
+					//
+					continue
+				}
 				// In this case we use the raw error-- the other attributes of
 				// *events.ErrorInfo will be sent along via the above call to
 				// span.SetAttributes
 				setError(span, v.RawError)
 			case error:
+				if v == nil {
+					continue
+				}
+
 				// Any log.Marshaler could also implement error, in which case we want
 				// to respect that the client intended to send an error, and set the
 				// appropriate attributes on the span


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it


passing events.NewErrorInfo(nil), a totally valid use case, was sufficient to cause a panic. This adds a smatterring of nil checks in the type switch to ensure we don't hit that.
<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
