### PR TITLE
feat(differs): add AnyFloat64

### DIFF
--- a/pkg/differs/floats.go
+++ b/pkg/differs/floats.go
@@ -11,3 +11,11 @@ func FloatRange(start, end float64) CustomComparer {
 		return ok && f >= start && f <= end
 	})
 }
+
+// AnyFloat allows any float value
+func AnyFloat() CustomComparer {
+	return Customf(func(o interface{}) bool {
+		_, ok := o.(float64)
+		return ok
+	})
+}

--- a/pkg/differs/floats.go
+++ b/pkg/differs/floats.go
@@ -12,8 +12,8 @@ func FloatRange(start, end float64) CustomComparer {
 	})
 }
 
-// AnyFloat allows any float value
-func AnyFloat() CustomComparer {
+// AnyFloat64 allows any float64 value
+func AnyFloat64() CustomComparer {
 	return Customf(func(o interface{}) bool {
 		_, ok := o.(float64)
 		return ok


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds a `differs.AnyFloat64()` function which allows any `float64` value when doing a diff using `cmp.Diff()`. This is an alternative to `FloatRange` where you do not care what the value is (e.g., duration) but want the value to be of a specific type.
