### PR TITLE
fix(logfile): handle []interface{} stringslice attribute conversion

### DIFF
--- a/pkg/cli/logfile/storage_entry_otel_test.go
+++ b/pkg/cli/logfile/storage_entry_otel_test.go
@@ -11,8 +11,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tdewolff/minify/v2"
 	minifyjson "github.com/tdewolff/minify/v2/json" // used by minify
+	"go.opentelemetry.io/otel/attribute"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"gotest.tools/v3/assert"
@@ -44,5 +46,128 @@ func TestTraceRoundtripJSON(t *testing.T) {
 
 	if diff := cmp.Diff(originalJSON.String(), string(newJSON)); diff != "" {
 		t.Fatalf("TestTraceRoundtripJSON() = %s", diff)
+	}
+}
+
+func TestAsAttributeKeyValue(t *testing.T) {
+	type args struct {
+		Type  string
+		value any
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want attribute.KeyValue
+	}{
+		{
+			name: "string",
+			args: args{
+				Type:  attribute.STRING.String(),
+				value: "value",
+			},
+			want: attribute.String("key", "value"),
+		},
+		{
+			name: "int64 (int64)",
+			args: args{
+				Type:  attribute.INT64.String(),
+				value: int64(1),
+			},
+			want: attribute.Int64("key", 1),
+		},
+		{
+			name: "int64 (float64)",
+			args: args{
+				Type:  attribute.INT64.String(),
+				value: float64(1.0),
+			},
+			want: attribute.Int64("key", 1),
+		},
+		{
+			name: "bool",
+			args: args{
+				Type:  attribute.BOOL.String(),
+				value: true,
+			},
+			want: attribute.Bool("key", true),
+		},
+		{
+			name: "float64",
+			args: args{
+				Type:  attribute.FLOAT64.String(),
+				value: float64(1.0),
+			},
+			want: attribute.Float64("key", 1.0),
+		},
+		{
+			name: "float64slice",
+			args: args{
+				Type:  attribute.FLOAT64SLICE.String(),
+				value: []float64{1.0, 2.0},
+			},
+			want: attribute.Float64Slice("key", []float64{1.0, 2.0}),
+		},
+		{
+			name: "int64slice (int64)",
+			args: args{
+				Type:  attribute.INT64SLICE.String(),
+				value: []int64{1, 2},
+			},
+			want: attribute.Int64Slice("key", []int64{1, 2}),
+		},
+		{
+			name: "int64slice (float64)",
+			args: args{
+				Type:  attribute.INT64SLICE.String(),
+				value: []float64{1.0, 2.0},
+			},
+			want: attribute.Int64Slice("key", []int64{1, 2}),
+		},
+		{
+			name: "boolslice",
+			args: args{
+				Type:  attribute.BOOLSLICE.String(),
+				value: []bool{true, false},
+			},
+			want: attribute.BoolSlice("key", []bool{true, false}),
+		},
+		{
+			name: "stringslice (strings)",
+			args: args{
+				Type:  attribute.STRINGSLICE.String(),
+				value: []string{"value1", "value2"},
+			},
+			want: attribute.StringSlice("key", []string{"value1", "value2"}),
+		},
+		{
+			name: "stringslice (interface of string)",
+			args: args{
+				Type:  attribute.STRINGSLICE.String(),
+				value: []interface{}{"value1", "value2"},
+			},
+			want: attribute.StringSlice("key", []string{"value1", "value2"}),
+		},
+		{
+			name: "stringslice (interface mixed)",
+			args: args{
+				Type:  attribute.STRINGSLICE.String(),
+				value: []interface{}{"value1", 2},
+			},
+			want: attribute.StringSlice("key", []string{"value1", "2"}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := keyValue{
+				Key:   "key",
+				Value: value{Type: tt.args.Type, Value: tt.args.value},
+			}
+
+			attr, err := kv.asAttributeKeyValue()
+			assert.NilError(t, err, "failed to convert key value to attribute key value")
+			assert.DeepEqual(t, attr, tt.want, cmpopts.IgnoreUnexported(attribute.Value{}))
+		})
 	}
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

JSON will sometimes convert mixed `stringslice` attributes into `[]interface{}` instead of `[]string`. This updates our attribute transformation logic to handle this, and to be more robust in general with tests and some other edgecase handling (e.g., `int64` always being `float64` might not be the case forever.)

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
