### PR TITLE
fix(DT-3663): Function names can be >2-part names, fixing module name calculator

### DIFF
--- a/pkg/callerinfo/callerinfo.go
+++ b/pkg/callerinfo/callerinfo.go
@@ -143,6 +143,9 @@ func calculateModule(funcName string) string {
 func parsePackageName(funcName string) string {
 	// Find the last segment of the URL path
 	index := strings.LastIndex(funcName, "/")
+	if index == -1 {
+		return "error:" + funcName
+	}
 	indexDot := strings.Index(funcName[index:], ".")
 	if indexDot == -1 {
 		return funcName

--- a/pkg/callerinfo/callerinfo.go
+++ b/pkg/callerinfo/callerinfo.go
@@ -141,10 +141,12 @@ func calculateModule(funcName string) string {
 // The function name looks like "github.com/getoutreach/gobox/pkg/callerinfo.Test_Callers", so parse the
 // package name out of the base
 func parsePackageName(funcName string) string {
-	// Pull off the last period and beyond
-	index := strings.LastIndex(funcName, ".")
-	if index == -1 {
-		return "error:" + funcName
+	// Find the last segment of the URL path
+	index := strings.LastIndex(funcName, "/")
+	indexDot := strings.Index(funcName[index:], ".")
+	if indexDot == -1 {
+		return funcName
 	}
-	return funcName[0:index]
+	// Pull off everything after the first period (and the period)
+	return funcName[0:(index + indexDot)]
 }

--- a/pkg/callerinfo/callerinfo_test.go
+++ b/pkg/callerinfo/callerinfo_test.go
@@ -7,6 +7,18 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func Test_ParsePackageName(t *testing.T) {
+	assert.Equal(t,
+		parsePackageName("github.com/getoutreach/gobox/pkg/foobar"),
+		"github.com/getoutreach/gobox/pkg/foobar")
+	assert.Equal(t,
+		parsePackageName("github.com/getoutreach/gobox/pkg/callerinfo.Test_Callers"),
+		"github.com/getoutreach/gobox/pkg/callerinfo")
+	assert.Equal(t,
+		parsePackageName("github.com/getoutreach/gobox/pkg/log.logger.Info"),
+		"github.com/getoutreach/gobox/pkg/log")
+}
+
 func Test_Callers(t *testing.T) {
 	assert.Equal(t, len(moduleLookupByPC), 0)
 

--- a/pkg/callerinfo/callerinfo_test.go
+++ b/pkg/callerinfo/callerinfo_test.go
@@ -17,6 +17,10 @@ func Test_ParsePackageName(t *testing.T) {
 	assert.Equal(t,
 		parsePackageName("github.com/getoutreach/gobox/pkg/log.logger.Info"),
 		"github.com/getoutreach/gobox/pkg/log")
+
+	assert.Equal(t,
+		parsePackageName("sdfdsfsed"),
+		"error:sdfdsfsed")
 }
 
 func Test_Callers(t *testing.T) {


### PR DESCRIPTION


<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it



<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
