### PR TITLE
fix(delibird): pass stdin to subproccess when not term

### DIFF
--- a/pkg/cli/logfile/logfile_unix.go
+++ b/pkg/cli/logfile/logfile_unix.go
@@ -190,16 +190,16 @@ func ptyOutputHook(l net.Listener, cmd *exec.Cmd, ptmx,
 		return nil, errors.Wrap(err, "failed to attach stdin to pty")
 	}
 
-	// forward os.Stdin to the PTY
-	//nolint:errcheck // Why: Best effort
-	go io.Copy(ptmx, os.Stdin)
-
 	finishedChan := make(chan struct{})
 
 	w, h, err := term.GetSize(int(os.Stdin.Fd()))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get terminal size")
 	}
+
+	// forward os.Stdin to the PTY
+	//nolint:errcheck // Why: Best effort
+	go io.Copy(ptmx, os.Stdin)
 
 	rec := newRecorder(logFile, w, h, cmd.Path, cmd.Args[1:], l)
 

--- a/pkg/cli/logfile/logfile_unix.go
+++ b/pkg/cli/logfile/logfile_unix.go
@@ -101,6 +101,7 @@ func Hook() error {
 
 		cmd.Stdout = io.MultiWriter(os.Stdout, rec)
 		cmd.Stderr = io.MultiWriter(os.Stderr, rec)
+		cmd.Stdin = os.Stdin
 		cmdErr = cmd.Run()
 
 		// Tell the trace server to shutdown

--- a/pkg/cli/logfile/logfile_unix.go
+++ b/pkg/cli/logfile/logfile_unix.go
@@ -33,7 +33,8 @@ func Hook() error {
 		return nil
 	}
 
-	isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
+	// if both stdin and stdout are not terminals, then we don't need a pty
+	isTerminal := term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR fixes the stdin logic to properly pass stdin to the created sub-process when running not as a terminal. When running in a terminal, this is properly handled by the `ptyOutputHook` function.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3742]


[DT-3742]: https://outreach-io.atlassian.net/browse/DT-3742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ