### PR TITLE
revert: support disabling logging for trace call methods (#300)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,7 +31,7 @@
     "editor.defaultFormatter": "redhat.vscode-yaml"
   },
   "gopls": {
-    "build.buildFlags": ["-tags=or_test,or_dev,or_int"]
+    "build.buildFlags": ["-tags=or_test,or_dev,or_e2e,or_int"]
   },
   "[terraform]": {
     "editor.defaultFormatter": "hashicorp.terraform"

--- a/internal/call/call.go
+++ b/internal/call/call.go
@@ -16,10 +16,9 @@ import (
 	"github.com/getoutreach/gobox/pkg/metrics"
 )
 
-// Type tracks the type of call being made.
+// Type tracks the call type.
 type Type string
 
-// Contains the call type constants.
 const (
 	// TypeHTTP is a constant that denotes the call type being an HTTP
 	// request.
@@ -36,30 +35,15 @@ const (
 
 // Info tracks information about an ongoing synchronous call.
 type Info struct {
-	// Name is the name of the call, this is used for the message of the log
-	// and the name of the trace.
 	Name string
-
-	// Type is the type of the call, see `Type` for more information.
 	Type Type
-
-	// Opts are the options for this call, see `Options` for more information.
-	Opts Options
-
-	// Kind is the type of call being made. See metrics.CallKind for more
-	// information.
 	Kind metrics.CallKind
-
-	// Args are the arguments to the call, this is used for attributes on
-	// logs and traces.
 	Args []logf.Marshaler
-
-	// ErrInfo is the information for an error that occurred during the call.
-	// This is set by SetStatus and used for reporting that an error occurred.
-	ErrInfo *events.ErrorInfo
 
 	events.Times
 	events.Durations
+
+	ErrInfo *events.ErrorInfo
 
 	mu sync.Mutex
 }
@@ -133,7 +117,8 @@ func (info *Info) MarshalLog(addField func(key string, value interface{})) {
 }
 
 // Tracker helps manage a call info via the context.
-type Tracker struct{}
+type Tracker struct {
+}
 
 // StartCall creates a new call Info object and returns a new context
 // where tracker.Info(ctx) will return the newly setup call Info object.
@@ -146,8 +131,6 @@ func (t *Tracker) StartCall(ctx context.Context, name string, args []logf.Marsha
 }
 
 // Info returns the call Info object stashed in the context.
-// If there is no call Info object, it returns nil. Be sure
-// to check for nil before using the returned value.
 func (t *Tracker) Info(ctx context.Context) *Info {
 	if v := ctx.Value(t); v != nil {
 		return v.(*Info)

--- a/internal/call/option.go
+++ b/internal/call/option.go
@@ -5,12 +5,5 @@ package call
 // Option defines the call Info adjustment function
 type Option func(c *Info)
 
-// Options contains options for all tracing calls.
-type Options struct {
-	// DisableInfoLogging turns off per-call info logging if set to true. If false, every successful
-	// (statuscodes.CategoryOK) call will have an Info line emitted.
-	DisableInfoLogging bool
-}
-
 // MarshalLog is defined for being compliant with trace.StartCall contract
 func (Option) MarshalLog(addField func(string, interface{})) {}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -14,19 +14,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// CallKind is the type of call that was made. This is meant to differentiate
-// between calls that are made to internal services vs calls that are made to
-// 3rd party (external) services.
 type CallKind string
 
 const (
-	// CallKindInternal is a call that was made to an internal service.
-	// "internal" represents a service that is within the same organization.
 	CallKindInternal CallKind = "internal"
-
-	// CallKindExternal is a call that was made to an external service.
-	// "external" represents a service that is outside of the organization, such
-	// as a 3rd party service.
 	CallKindExternal CallKind = "external"
 )
 

--- a/pkg/trace/call_option.go
+++ b/pkg/trace/call_option.go
@@ -5,22 +5,12 @@
 package trace
 
 import (
-	"context"
 	"time"
 
 	"github.com/getoutreach/gobox/internal/call"
 )
 
-// CallOptions contains options for all tracing calls. See
-// call.Options for more information.
-type CallOptions call.Options
-
-// WithScheduledTime sets the call scheduled time to the provided
-// time. Normally, this is set automatically by StartCall.
-//
-// Example:
-//
-//	ctx = trace.StartCall(ctx, "http", log.F{"query": query}, trace.WithScheduledTime(time.Now()))
+// WithScheduledTime set the call Info scheduled at time
 func WithScheduledTime(t time.Time) call.Option {
 	return func(c *call.Info) {
 		c.Times.Scheduled = t
@@ -45,27 +35,5 @@ func AsHTTPCall() call.Option {
 func AsOutboundCall() call.Option {
 	return func(c *call.Info) {
 		c.Type = call.TypeOutbound
-	}
-}
-
-// SetCallOptions sets the provided call options on the current call in the
-// provided context. The provided options replace any existing options.
-// Call options are not preserved across application boundaries.
-//
-// Example:
-//
-//	ctx = trace.StartCall(ctx, "http", trace.WithCallOptions(ctx, trace.CallOptions{DisableInfoLogging: true}))
-func WithCallOptions(ctx context.Context, opts CallOptions) {
-	callTracker.Info(ctx).Opts = call.Options(opts)
-}
-
-// WithInfoLoggingDisabled disables info logging on the current call
-//
-// Example:
-//
-//	ctx = trace.StartCall(ctx, "http", trace.WithInfoLoggingDisabled())
-func WithInfoLoggingDisabled() call.Option {
-	return func(c *call.Info) {
-		c.Opts.DisableInfoLogging = true
 	}
 }

--- a/pkg/trace/call_option_test.go
+++ b/pkg/trace/call_option_test.go
@@ -6,13 +6,7 @@ import (
 	"time"
 
 	"github.com/getoutreach/gobox/internal/call"
-	"github.com/getoutreach/gobox/internal/logf"
-	"github.com/getoutreach/gobox/pkg/differs"
-	"github.com/getoutreach/gobox/pkg/log"
-	"github.com/getoutreach/gobox/pkg/log/logtest"
 	"github.com/getoutreach/gobox/pkg/trace"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 )
 
@@ -43,62 +37,4 @@ func TestAsGRPCCall(t *testing.T) {
 func TestAsOutboundCall(t *testing.T) {
 	callInfo := startCall(trace.AsOutboundCall())
 	assert.Equal(t, call.TypeOutbound, callInfo.Type)
-}
-
-// ignoreVariableFields ignores the "deployment.namespace" and
-// "app.version" fields because they can be variable across testing
-// environments.
-func ignoreVariableFields() cmp.Option {
-	return cmpopts.IgnoreMapEntries(func(key string, value interface{}) bool {
-		return key == "deployment.namespace" || key == "app.version"
-	})
-}
-
-func TestWithInfoLoggingDisabled(t *testing.T) {
-	// Test that the default is false
-	callInfo := startCall(func(c *call.Info) {})
-	assert.Equal(t, false, callInfo.Opts.DisableInfoLogging)
-
-	// Test that trace.WithInfoLoggingDisabled() sets the DisableInfoLogging
-	// option to true.
-	callInfo = startCall(trace.WithInfoLoggingDisabled())
-	assert.Equal(t, true, callInfo.Opts.DisableInfoLogging)
-
-	// Make a call and ensure that info logs are not emitted.
-	recorder := logtest.NewLogRecorder(t)
-	defer recorder.Close()
-
-	ctx := trace.StartCall(context.Background(), "test", trace.WithInfoLoggingDisabled())
-	trace.EndCall(ctx)
-
-	if diff := cmp.Diff([]logf.F(nil), recorder.Entries(), differs.Custom()); diff != "" {
-		t.Fatal("unexpected events", diff)
-	}
-
-	// now make a call with info logging enabled and ensure that info logs are
-	// emitted.
-	ctx = trace.StartCall(context.Background(), "test")
-	trace.EndCall(ctx)
-
-	expected := []log.F{
-		{
-			"@timestamp":          differs.AnyString(),
-			"event_name":          "trace",
-			"honeycomb.parent_id": differs.AnyString(),
-			"honeycomb.span_id":   differs.AnyString(),
-			"honeycomb.trace_id":  differs.AnyString(),
-			"level":               "INFO",
-			"message":             "test",
-			"module":              "github.com/getoutreach/gobox",
-			"timing.dequeued_at":  differs.AnyString(),
-			"timing.finished_at":  differs.AnyString(),
-			"timing.scheduled_at": differs.AnyString(),
-			"timing.service_time": differs.AnyFloat64(),
-			"timing.total_time":   differs.AnyFloat64(),
-			"timing.wait_time":    differs.AnyFloat64(),
-		},
-	}
-	if diff := cmp.Diff(expected, recorder.Entries(), differs.Custom(), ignoreVariableFields()); diff != "" {
-		t.Fatal("unexpected events", diff)
-	}
 }

--- a/pkg/trace/call_test.go
+++ b/pkg/trace/call_test.go
@@ -37,7 +37,7 @@ func (m *Model) MarshalLog(addField func(k string, v interface{})) {
 	addField("model.id", m.ID)
 }
 
-func TestNestedCall(t *testing.T) {
+func (suite) TestNestedCall(t *testing.T) {
 	t.Skip("flaky test")
 
 	defer app.SetName(app.Info().Name)
@@ -354,13 +354,13 @@ func getMetricsInfo(t *testing.T) []map[string]interface{} {
 	return result
 }
 
-func TestEndCallDoesNotPanicWithNilError(t *testing.T) {
+func (suite) TestEndCallDoesNotPanicWithNilError(t *testing.T) {
 	t.Skip("requires method to clear metrics between tests")
 
 	ctx := trace.StartCall(context.Background(), "")
 	trace.EndCall(ctx)
 }
 
-func TestSetCallStatusDoesNotPanicWithNilInfo(t *testing.T) {
+func (suite) TestSetCallStatusDoesNotPanicWithNilInfo(t *testing.T) {
 	trace.SetCallStatus(context.Background(), errors.New(""))
 }

--- a/pkg/trace/propagation_test.go
+++ b/pkg/trace/propagation_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestForceTracingByHeader(t *testing.T) {
+func (suite) TestForceTracingByHeader(t *testing.T) {
 	defer app.SetName(app.Info().Name)
 	app.SetName("gobox")
 
@@ -104,7 +104,7 @@ func TestForceTracingByHeader(t *testing.T) {
 	}
 }
 
-func TestHeadersForceTracingByHeader(t *testing.T) {
+func (suite) TestHeadersForceTracingByHeader(t *testing.T) {
 	defer app.SetName(app.Info().Name)
 	app.SetName("gobox")
 
@@ -170,7 +170,7 @@ func TestHeadersForceTracingByHeader(t *testing.T) {
 	}
 }
 
-func TestForceTracing(t *testing.T) {
+func (suite) TestForceTracing(t *testing.T) {
 	defer app.SetName(app.Info().Name)
 	app.SetName("gobox")
 

--- a/pkg/trace/roundtripper_test.go
+++ b/pkg/trace/roundtripper_test.go
@@ -21,7 +21,7 @@ import (
 type initRoundTripperStateFunc func(t *testing.T) *roundtripperState
 type callRoudTripperFunc func(t *testing.T, state *roundtripperState) []map[string]interface{}
 
-func TestRoundtripper(t *testing.T) {
+func (suite) TestRoundtripper(t *testing.T) {
 	defer app.SetName(app.Info().Name)
 	app.SetName("gobox")
 

--- a/pkg/trace/trace_test.go
+++ b/pkg/trace/trace_test.go
@@ -22,7 +22,7 @@ func TestAll(t *testing.T) {
 
 type suite struct{}
 
-func TestNestedSpan(t *testing.T) {
+func (suite) TestNestedSpan(t *testing.T) {
 	defer app.SetName(app.Info().Name)
 	app.SetName("gobox")
 
@@ -166,7 +166,7 @@ func TestNestedSpan(t *testing.T) {
 	}
 }
 
-func TestIncludesDevEmail(t *testing.T) {
+func (suite) TestIncludesDevEmail(t *testing.T) {
 	defer app.SetName(app.Info().Name)
 	app.SetName("gobox")
 


### PR DESCRIPTION
Reverts getoutreach/gobox#300

[DT-3752]

**[Slack Context](https://outreach-hq.slack.com/archives/CN9MU7GLW/p1684526326001109)**

[DT-3752]: https://outreach-io.atlassian.net/browse/DT-3752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ