### PR TITLE
fix(trace): restore previous callinfo check behaviour

### DIFF
--- a/pkg/trace/call.go
+++ b/pkg/trace/call.go
@@ -106,13 +106,6 @@ func SetCallError(ctx context.Context, err error) error {
 // rethrows them.  Any panics are converted to errors and cause error
 // logging to happen (as do any SetCallStatus calls)
 func EndCall(ctx context.Context) {
-	callInfo := callTracker.Info(ctx)
-	if callInfo == nil {
-		// There was no call associated with this context, so we can't
-		// do anything.
-		return
-	}
-
 	defer End(ctx)
 
 	defer func(info *call.Info) {
@@ -133,7 +126,7 @@ func EndCall(ctx context.Context) {
 		} else if !info.Opts.DisableInfoLogging {
 			log.Info(ctx, info.Name, info, IDs(ctx), traceEventMarker{})
 		}
-	}(callInfo)
+	}(callTracker.Info(ctx))
 
 	callTracker.EndCall(ctx)
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Another attempt at fixing [DT-3752], this is the only real change I can tell that happened that could potentially break anything. `addDefaultTracerInfo` seems like it could be connected, but I cannot for the life of me figure out what that code is doing... so here's my attempt at letting it be and maybe that'll somehow fix the bug.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3752]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3752]: https://outreach-io.atlassian.net/browse/DT-3752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3752]: https://outreach-io.atlassian.net/browse/DT-3752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ