### PR TITLE
feat: add status codes for deadline and canceled

### DIFF
--- a/pkg/statuscodes/statuscodes.go
+++ b/pkg/statuscodes/statuscodes.go
@@ -15,12 +15,14 @@ const (
 	OK StatusCode = 600
 
 	// Client-caused error responses
-	BadRequest   StatusCode = 700
-	Unauthorized StatusCode = 701
-	Forbidden    StatusCode = 702
-	NotFound     StatusCode = 703
-	Conflict     StatusCode = 704
-	RateLimited  StatusCode = 705
+	BadRequest       StatusCode = 700
+	Unauthorized     StatusCode = 701
+	Forbidden        StatusCode = 702
+	NotFound         StatusCode = 703
+	Conflict         StatusCode = 704
+	RateLimited      StatusCode = 705
+	DeadlineExceeded StatusCode = 706
+	Canceled         StatusCode = 707
 
 	// Server-caused error responses
 	InternalServerError StatusCode = 800
@@ -91,6 +93,10 @@ func FromString(s string) (StatusCode, bool) {
 		return Unavailable, true
 	case UnknownError.String():
 		return UnknownError, true
+	case DeadlineExceeded.String():
+		return DeadlineExceeded, true
+	case Canceled.String():
+		return Canceled, true
 	default:
 		return UnknownError, false
 	}

--- a/pkg/statuscodes/statuscodes_test.go
+++ b/pkg/statuscodes/statuscodes_test.go
@@ -15,6 +15,8 @@ func TestStatusCodeUnmarshalText(t *testing.T) {
 		NotImplemented,
 		Unavailable,
 		UnknownError,
+		DeadlineExceeded,
+		Canceled,
 	}
 
 	for _, code := range codes {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

I'm migrating `mailroomapi` service from returning grpc status codes directly to gobox error codes in order to make the tracing properly (even client side errors are logged as server errors into telemetry now).

To support all of the current grpc codes used by `mailroomapi`, I'm adding two new codes for `DeadlineExceeded` and `Canceled`. 

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
