### PR TITLE
feat: allow self-classification of errors

### DIFF
--- a/pkg/orerr/statuscodewrap.go
+++ b/pkg/orerr/statuscodewrap.go
@@ -10,6 +10,10 @@ import (
 	"github.com/getoutreach/gobox/pkg/statuscodes"
 )
 
+type StatusCodeProvider interface {
+	StatusCode() statuscodes.StatusCode
+}
+
 type StatusCategoryProvider interface {
 	StatusCategory() statuscodes.StatusCategory
 }
@@ -40,9 +44,9 @@ func NewErrorStatus(errToWrap error, errCode statuscodes.StatusCode) error {
 }
 
 func IsErrorStatusCode(err error, code statuscodes.StatusCode) bool {
-	var scw *StatusCodeWrapper
-	if errors.As(err, &scw) {
-		return scw.code == code
+	var scp StatusCodeProvider
+	if errors.As(err, &scp) {
+		return scp.StatusCode() == code
 	}
 	return false
 }
@@ -56,9 +60,9 @@ func IsErrorStatusCategory(err error, category statuscodes.StatusCategory) bool 
 }
 
 func ExtractErrorStatusCode(err error) statuscodes.StatusCode {
-	var scw *StatusCodeWrapper
-	if errors.As(err, &scw) {
-		return scw.StatusCode()
+	var scp StatusCodeProvider
+	if errors.As(err, &scp) {
+		return scp.StatusCode()
 	}
 	return statuscodes.UnknownError
 }

--- a/pkg/orerr/statuscodewrap.go
+++ b/pkg/orerr/statuscodewrap.go
@@ -10,6 +10,10 @@ import (
 	"github.com/getoutreach/gobox/pkg/statuscodes"
 )
 
+type StatusCategoryProvider interface {
+	StatusCategory() statuscodes.StatusCategory
+}
+
 type StatusCodeWrapper struct {
 	wrappedErr error
 	code       statuscodes.StatusCode
@@ -44,9 +48,9 @@ func IsErrorStatusCode(err error, code statuscodes.StatusCode) bool {
 }
 
 func IsErrorStatusCategory(err error, category statuscodes.StatusCategory) bool {
-	var scw *StatusCodeWrapper
-	if errors.As(err, &scw) {
-		return scw.StatusCategory() == category
+	var scp StatusCategoryProvider
+	if errors.As(err, &scp) {
+		return scp.StatusCategory() == category
 	}
 	return false
 }
@@ -60,9 +64,9 @@ func ExtractErrorStatusCode(err error) statuscodes.StatusCode {
 }
 
 func ExtractErrorStatusCategory(err error) statuscodes.StatusCategory {
-	var scw *StatusCodeWrapper
-	if errors.As(err, &scw) {
-		return scw.StatusCategory()
+	var scp StatusCategoryProvider
+	if errors.As(err, &scp) {
+		return scp.StatusCategory()
 	}
 	return statuscodes.CategoryServerError
 }

--- a/pkg/orerr/statuscodewrap_test.go
+++ b/pkg/orerr/statuscodewrap_test.go
@@ -12,16 +12,30 @@ import (
 	"github.com/getoutreach/gobox/pkg/statuscodes"
 )
 
-func (suite) Basics(t *testing.T) {
+func (suite) TestClientSideError(t *testing.T) {
 	erro := errors.New("bad")
 	err := orerr.NewErrorStatus(erro, statuscodes.Forbidden)
 
 	//nolint:errorlint // Why: test
 	assert.Equal(t, err.(*orerr.StatusCodeWrapper).StatusCode(), statuscodes.Forbidden)
 	//nolint:errorlint // Why: test
-	assert.Equal(t, err.(*orerr.StatusCodeWrapper).StatusCategory(), statuscodes.CategoryServerError)
+	assert.Equal(t, err.(*orerr.StatusCodeWrapper).StatusCategory(), statuscodes.CategoryClientError)
 	assert.Assert(t, orerr.IsErrorStatusCode(err, statuscodes.Forbidden))
 	assert.Assert(t, orerr.IsErrorStatusCategory(err, statuscodes.CategoryClientError))
 	assert.Assert(t, !orerr.IsErrorStatusCategory(err, statuscodes.CategoryServerError))
+	assert.Assert(t, !orerr.IsErrorStatusCategory(err, statuscodes.CategoryOK))
+}
+
+func (suite) TestServerSideError(t *testing.T) {
+	erro := errors.New("bad")
+	err := orerr.NewErrorStatus(erro, statuscodes.InternalServerError)
+
+	//nolint:errorlint // Why: test
+	assert.Equal(t, err.(*orerr.StatusCodeWrapper).StatusCode(), statuscodes.InternalServerError)
+	//nolint:errorlint // Why: test
+	assert.Equal(t, err.(*orerr.StatusCodeWrapper).StatusCategory(), statuscodes.CategoryServerError)
+	assert.Assert(t, orerr.IsErrorStatusCode(err, statuscodes.InternalServerError))
+	assert.Assert(t, orerr.IsErrorStatusCategory(err, statuscodes.CategoryServerError))
+	assert.Assert(t, !orerr.IsErrorStatusCategory(err, statuscodes.CategoryClientError))
 	assert.Assert(t, !orerr.IsErrorStatusCategory(err, statuscodes.CategoryOK))
 }


### PR DESCRIPTION
<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Allow errors to implement:

```golang
StatusCategory() statuscodes.StatusCategory
```

and if it's implemented, use that category. This allows for greater flexibility when deciding how to categorize errors that don't fit the predefined status codes.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

TESTED=go test -v -race -count=1 -tags=or_test,or_int ./pkg/orerr/...

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
