### PR TITLE
feat: Extend SnapshotTarget with RestoreSteps

### DIFF
--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -209,13 +209,20 @@ type SnapshotTarget struct {
 	// ReadyAddress is a URL to ping before marking the devenv as ready
 	ReadyAddress string `yaml:"readyAddress"`
 
-	// RestoreSteps defines which steps are used for restore
+	// RestoreSteps defines the startup order of the resources within this snapshot.
+	// If not specified, all snapshot resources are started at the same time
 	RestoreSteps []RestoreStep `yaml:"restore_steps"`
 }
 
-// RestoreStep is the defn for a restore step
+// RestoreStep maps to a set of resources included in the snapshot.
+//
+// Examples:
+//
+// - a "databases" step specifies "IncludedNamespaces" of all database namespaces
+//
+// - a "all the rest" step only specifies "ExcludedNamespaces" used in previous steps
 type RestoreStep struct {
-	// Description allows to specify what's this intended to exactly
+	// Description describes what resources are restored in this step
 	Description string
 
 	// IncludedNamespaces defines what namespaces are restored in this step. It maps to Velero IncludedNamespaces restore parameter

--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -208,6 +208,21 @@ type SnapshotTarget struct {
 
 	// ReadyAddress is a URL to ping before marking the devenv as ready
 	ReadyAddress string `yaml:"readyAddress"`
+
+	// RestoreSteps defines which steps are used for restore
+	RestoreSteps []RestoreStep `yaml:"restore_steps"`
+}
+
+// RestoreStep is the defn for a restore step
+type RestoreStep struct {
+	// Description allows to specify what's this intended to exactly
+	Description string
+
+	// IncludedNamespaces defines what namespaces are restored in this step. It maps to Velero IncludedNamespaces restore parameter
+	IncludedNamespaces []string `yaml:"included_namespaces"`
+
+	// ExcludedNamespaces defines what namespaces are not restored in this step. It maps to Velero ExcludedNamespaces restore parameter
+	ExcludedNamespaces []string `yaml:"excluded_namespaces"`
 }
 
 // SnapshotGenerateConfig stores configuration for snapshots that should be generated


### PR DESCRIPTION
This is the first part of 3 changes. Following changes are:
- Define Restore steps in devenv-snapshots https://github.com/getoutreach/devenv-snapshots/pull/130
- Support Restore steps in devenv: https://github.com/getoutreach/devenv/pull/677

[QF-909](https://outreach-io.atlassian.net/browse/QF-909)

[QF-909]: https://outreach-io.atlassian.net/browse/QF-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ