### PR TITLE
feat: port context-aware cond to gobox

### DIFF
--- a/pkg/async/cond.go
+++ b/pkg/async/cond.go
@@ -1,0 +1,94 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: Cond.go provides a context respecting sync condition
+
+package async
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// Cond is a sync.Cond that respects context cancellation.
+// It provides equivalent functionality to sync.Cond (excepting there is no `Signal` method), except that
+// the Wait method exits with error if the context cancels.
+type Cond struct {
+	pointer atomic.Pointer[chan struct{}]
+	mu      sync.Mutex
+}
+
+// ch returns the channel that Waiters are waiting on, possibly creating one if it doesn't exist.
+func (c *Cond) ch() chan struct{} {
+	t := make(chan struct{})
+	c.pointer.CompareAndSwap(nil, &t)
+	return *c.pointer.Load()
+}
+
+// Wait waits for the state change Broadcast until context ends.
+func (c *Cond) Wait(ctx context.Context) error {
+	select {
+	case <-c.ch():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Broadcast signals the state change to all Waiters
+func (c *Cond) Broadcast() {
+	ch := c.ch()
+	// now that we retrieved the channel, new calls to Wait should get a new channel
+	c.pointer.Store(nil)
+	close(ch)
+}
+
+// WaitForCondition checks if the condition is true or the context is done, otherwise
+// it waits for the state change Broadcast.
+//
+// if it returns without error, it also locks the provided locker and the caller must call the returned function
+// to unlock it. Until they call unlock, the state should not be changed.
+func (c *Cond) WaitForCondition(ctx context.Context, locker sync.Locker, condition func() bool) (func(), error) {
+	for {
+		err := c.lockWithContext(ctx, locker)
+		if err != nil {
+			return func() {}, err
+		}
+
+		// we have the lock, we can safely check the condition
+		ok := condition()
+
+		if !ok {
+			// condition not met
+			// but we acquired the lock. so unlock it...
+			locker.Unlock()
+
+			// either way, wait for the next signal
+			waitErr := c.Wait(ctx)
+			if waitErr != nil {
+				return func() {}, waitErr
+			}
+		} else {
+			// condition met, return the unlock function and nil error
+			// client must call the unlock function to unlock the mutex
+			// client guaranteed the condition holds while mutex lock is held.
+			return locker.Unlock, nil
+		}
+	}
+}
+
+// lockWithContext waits to either acquire the lock or for the context to end.
+// It returns an error if context ends before it can acquire the lock
+func (c *Cond) lockWithContext(ctx context.Context, locker sync.Locker) error {
+	lockAcquired := make(chan struct{})
+	go func() {
+		locker.Lock()
+		close(lockAcquired)
+	}()
+	select {
+	case <-lockAcquired:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}

--- a/pkg/async/cond_test.go
+++ b/pkg/async/cond_test.go
@@ -1,0 +1,194 @@
+package async
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestCond(t *testing.T) {
+
+	t.Run("broadcast wakes up waiter", func(t *testing.T) {
+		cond := Cond{}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		go func() {
+			time.Sleep(50 * time.Millisecond) // just a breath so the other goroutine goes first
+			cond.Broadcast()
+		}()
+
+		err := cond.Wait(ctx)
+		assert.Nil(t, err)
+	})
+
+	t.Run("can safely interleave broadcasts", func(t *testing.T) {
+		cond := Cond{}
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel()
+		for j := 0; j < 10; j++ {
+			start := make(chan struct{})
+			g, ctx := errgroup.WithContext(ctx)
+			g.Go(func() error {
+				return cond.Wait(ctx)
+			})
+			for i := 0; i < 10; i++ {
+				g.Go(func() error {
+					<-start
+					cond.Broadcast()
+					return nil
+				})
+			}
+			g.Go(func() error {
+				time.Sleep(10 * time.Millisecond) // just a breath so the other goroutine goes first
+				close(start)
+				return nil
+			})
+			err := g.Wait()
+			assert.Nil(t, err)
+		}
+	})
+
+	t.Run("broadcast wakes all waiters", func(t *testing.T) {
+		cond := Cond{}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		g, ctx := errgroup.WithContext(ctx)
+		// start everyone waiting
+		for i := 0; i < 10; i++ {
+			g.Go(func() error {
+				return cond.Wait(ctx)
+			})
+		}
+
+		// wake em all up
+		g.Go(func() error {
+			time.Sleep(10 * time.Millisecond) // just a breath so the other goroutine goes first
+			cond.Broadcast()
+			return nil
+		})
+
+		err := g.Wait()
+		assert.Nil(t, err)
+	})
+
+	t.Run("waiter exits on context cancel", func(t *testing.T) {
+		cond := Cond{}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go func() {
+			time.Sleep(50 * time.Millisecond) // just a breath so the other goroutine goes first
+			cancel()
+		}()
+
+		err := cond.Wait(ctx)
+		assert.Equal(t, context.Canceled, err)
+	})
+}
+
+func TestCond_WaitForCondition(t *testing.T) {
+	cond := Cond{}
+	t.Run("returns immediately, without error if the lock is free and the condition is met", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		mu := &sync.Mutex{}
+		unlock, err := cond.WaitForCondition(ctx, mu, func() bool {
+			return true
+		})
+		assert.Nil(t, err)
+		assert.False(t, mu.TryLock()) // it was able to lock m
+
+		// the returned function unlocks mu
+		unlock()
+		assert.True(t, mu.TryLock())
+	})
+
+	t.Run("blocks until lock is free if condition is met", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mu := &sync.Mutex{}
+		mu.Lock() // lock it so the condition isn't evaluated until we unlock it
+		waitedForUnlock := false
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			mu.Unlock()
+			waitedForUnlock = true
+		}()
+		unlock, err := cond.WaitForCondition(ctx, mu, func() bool {
+			return true
+		})
+		assert.True(t, waitedForUnlock)
+
+		assert.Nil(t, err)
+		assert.False(t, mu.TryLock()) // it is locked
+		// the returned function unlocks mu
+		unlock()
+		assert.True(t, mu.TryLock())
+	})
+
+	t.Run("blocks until condition is met", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mu := &sync.Mutex{}
+
+		var i = 0
+		unlock, err := cond.WaitForCondition(ctx, mu, func() bool {
+			go func() {
+				i++
+				cond.Broadcast()
+			}()
+			return i > 5
+		})
+
+		assert.Nil(t, err)
+		assert.False(t, mu.TryLock()) // it is locked
+		// the returned function unlocks mu
+		unlock()
+		assert.True(t, mu.TryLock())
+	})
+
+	t.Run("respects context expiry; even if locked", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		mu := &sync.Mutex{}
+		mu.Lock()
+
+		go func() {
+			time.Sleep(50 * time.Millisecond) // just a breath so the other goroutine goes first
+			cancel()
+		}()
+
+		fn, err := cond.WaitForCondition(ctx, mu, func() bool {
+			return true
+		})
+		defer fn()
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("respects context expiry; if lock is free", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		mu := &sync.Mutex{}
+
+		go func() {
+			time.Sleep(50 * time.Millisecond) // just a breath so the other goroutine goes first
+			cancel()
+		}()
+
+		fn, err := cond.WaitForCondition(ctx, mu, func() bool {
+			return false
+		})
+		defer fn()
+		assert.Equal(t, context.Canceled, err)
+	})
+}


### PR DESCRIPTION
I've been using this for a few months in polaroid (non-generic version), so I figured it's reasonable at this point to port it to GoBox,

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it



<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
