### PR TITLE
feat: Deprecate async/pool in favor of github.com/sourcegraph/conc/pool

### DIFF
--- a/pkg/async/pool/ORIGINAL_README.md
+++ b/pkg/async/pool/ORIGINAL_README.md
@@ -1,0 +1,129 @@
+# Goroutine worker pool structure
+
+Universal structure for controlling the right level of concurrency. Excessive spawning of goroutines might lead to resource exhaustion or slowing down due to heavy context switching.
+
+You might think that Go routines are relatively cheap, but they are not for free. So choosing the right level of concurrency might help to improve overall performance and throughput of the system. See the benchmarks.
+
+Something you might not realize when migrating from ruby. For example, every Http request in GO operates in goroutine already. There is no default limit on how many of these can be spawned (Possibly limit of opened descriptors, ports, etc). Under the DDOS or heavy request rate system will linearly slow down due to context switching. Ruby server in opposite usually runs with a fixed number of threads. If not a thread is available in the specified interval you are getting a timeout.
+
+Also, the pool prevents the application from being killed by OOM killer due to higher memory consumption
+
+The library was developed for MailroomAPI and used to limit the number of concurrent calls to S3. When there was unbounded processing using just goroutines application got often killed by OOM killer under heavy load.
+
+<https://github.com/getoutreach/mailroomapi/blob/master/internal/mailroomapi/storage/concurrent_message_reader.go>
+
+I have bumped into that issue already in the past. Here is a nice article to read.
+<https://medium.com/smsjunk/handling-1-million-requests-per-minute-with-golang-f70ac505fcaa>
+
+## Benchmarks
+
+Goal here is to process 10000 "cpu heavy" operations.
+
+| Benchmark           | Description                                                             |
+| ------------------- | ----------------------------------------------------------------------- |
+| BenchmarkPureGo     | Spawning goroutine for each task and waiting for all of them to finish. |
+| BenchmarkPool5-1000 | Putting them into pool and processing just N items at once.             |
+
+```bash
+go test -benchmem -cpu 1,2,6 -run=^$ github.com/getoutreach/gobox/pkg/async/pool -v -bench '^Benchmark'
+goos: linux
+goarch: amd64
+pkg: github.com/getoutreach/gobox/pkg/async/pool
+BenchmarkPool1000
+BenchmarkPool1000-6            1        1560899231 ns/op        234332864 B/op  20031897 allocs/op
+BenchmarkPool100
+BenchmarkPool100-6             1        1156778012 ns/op        233000224 B/op  20020978 allocs/op
+BenchmarkPool10
+BenchmarkPool10-6              1        1092621750 ns/op        232935976 B/op  20020126 allocs/op
+BenchmarkPool5
+BenchmarkPool5-6               1        1313762356 ns/op        232909576 B/op  20019824 allocs/op
+BenchmarkPureGo
+BenchmarkPureGo-6              1        2264417948 ns/op        237819960 B/op  20034677 allocs/op
+PASS
+ok  	github.com/getoutreach/gobox/pkg/async/pool	28.360s
+
+```
+
+## Insides
+
+- Currently structure utilize standard go channels that are more universal.
+- "Pool of workers" allow you to timeout without item being enqueued in opposite to pure "worker pool".
+
+### Example
+
+```go
+package main
+
+import (
+  "fmt"
+  "context"
+  "fmt"
+  "github.com/getoutreach/gobox/pkg/async/pool"
+)
+
+func main() {
+  var (
+    concurrency = 5
+    items       = 10
+    sleepFor    = 5 * time.Millisecond
+  )
+
+  ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+  defer cancel()
+
+    // Spawn pool of workers
+  p := pool.New(ctx,
+    pool.ConstantSize(concurrency),
+    pool.ResizeEvery(5*time.Minute),
+    pool.BufferLength(256),
+    pool.WaitWhenFull,
+  )
+  defer p.Close()
+
+    // Wrap it with timeout for schedule
+  scheduler = pool.WithTimeout(5 * time.Millisecond, p)
+
+    // Lets wait for items scheduled with this example
+  scheduler, wait := pool.WithWait(scheduler)
+
+  output := make(chan string, items)
+  now := time.Now()
+
+  for i := 0; i < items; i++ {
+    func(i int) {
+            // All input and output is captured by closure
+      scheduler.Schedule(ctx, async.Func(func(ctx context.Context) error {
+        if ctx.Err() != nil {
+          // It is very important to check the context error:
+          // - Given context might be done
+          // - Underlying buffered channel is full
+          // - Pool is in shutdown phase
+          return ctx.Err()
+        }
+        time.Sleep(sleepFor)
+        batchN := (time.Since(now) / (sleepFor))
+        output <- fmt.Sprintf("task_%d_%d", batchN, i)
+                // returned error is logged but not returned by Schedule function
+        return nil
+      })
+    }(i)
+  }
+  wait()
+
+  close(output)
+  for s := range output{
+    fmt.Println(s)
+  }
+  // Unordered output:
+  // task_1_3
+  // task_1_4
+  // task_1_0
+  // task_1_1
+  // task_1_2
+  // task_2_6
+  // task_2_9
+  // task_2_5
+  // task_2_7
+  // task_2_8
+}
+```

--- a/pkg/async/pool/README.md
+++ b/pkg/async/pool/README.md
@@ -36,7 +36,10 @@ p.Schedule(ctx, async.Func(func(ctx context.Context) error {
 p := pool.New().WithContext(ctx).WithMaxGoroutines(numOfWorkers)
 
 // blocks if there is no available worker.
-p.Go(func(ctx context.Context) error {
+//
+// Note: Use `pool.New().WithErrors()` if you want to keep the
+// `func(ctx) error` signature.
+p.Go(func(ctx context.Context) {
   // Do work
 })
 
@@ -70,7 +73,9 @@ wait()
 ```go
 p := pool.New().WithContext(ctx).WithMaxGoroutines(numOfWorkers)
 
-go p.Go(func(ctx context.Context) error {
+// Note: Use `pool.New().WithErrors()` if you want to keep the
+// `func(ctx) error` signature.
+go p.Go(func(ctx context.Context) {
   // Do work
 })
 

--- a/pkg/async/pool/README.md
+++ b/pkg/async/pool/README.md
@@ -1,129 +1,82 @@
-Goroutine worker pool structure
+# async/pool
 
-Universal structure for controlling the right level of concurrency. Excessive spawning of goroutines might lead to resource exhaustion or slowing down due to heavy context switching.
+This package is currently deprecated in favor of
+[github.com/sourcegraph/conc/pool](https://pkg.go.dev/github.com/sourcegraph/conc/pool).
 
-You might think that Go routines are relatively cheap, but they are not for free. So choosing the right level of concurrency might help to improve overall performance and throughput of the system. See the benchmarks.
+## Migrating
 
-Something you might not realize when migrating from ruby. For example, every Http request in GO operates in goroutine already. There is no default limit on how many of these can be spawned (Possibly limit of opened descriptors, ports, etc). Under the DDOS or heavy request rate system will linearly slow down due to context switching. Ruby server in opposite usually runs with a fixed number of threads. If not a thread is available in the specified interval you are getting a timeout.
+Most of the functionality from the original package is available in the
+`conc/pool` package. The main difference is that there is no ability to
+control what happens when a worker is unavailable. Previously, one could
+include a dynamically resizable buffer or constant size buffer and how
+Schedule would react when the buffer was full. This is no longer
+possible, instead there is no buffer and the `Go` method will always
+block until a worker is available.
 
-Also, the pool prevents the application from being killed by OOM killer due to higher memory consumption
+### Creating a constant pool for workers (`pool.New`)
 
-The library was developed for MailroomAPI and used to limit the number of concurrent calls to S3. When there was unbounded processing using just goroutines application got often killed by OOM killer under heavy load.
+The majority use case of this package was to create a pool of
+goroutines, of a specific size, that would process work.
 
-https://github.com/getoutreach/mailroomapi/blob/master/internal/mailroomapi/storage/concurrent_message_reader.go
-
-I have bumped into that issue already in the past. Here is a nice article to read.
-https://medium.com/smsjunk/handling-1-million-requests-per-minute-with-golang-f70ac505fcaa
-
-# Benchmarks
-
-Goal here is to process 10000 "cpu heavy" operations.
-
-| Benchmark           | Description                                                             |
-| ------------------- | ----------------------------------------------------------------------- |
-| BenchmarkPureGo     | Spawning goroutine for each task and waiting for all of them to finish. |
-| BenchmarkPool5-1000 | Putting them into pool and processing just N items at once.             |
-
-```
-go test -benchmem -cpu 1,2,6 -run=^$ github.com/getoutreach/gobox/pkg/async/pool -v -bench '^Benchmark'
-goos: linux
-goarch: amd64
-pkg: github.com/getoutreach/gobox/pkg/async/pool
-BenchmarkPool1000
-BenchmarkPool1000-6            1        1560899231 ns/op        234332864 B/op  20031897 allocs/op
-BenchmarkPool100
-BenchmarkPool100-6             1        1156778012 ns/op        233000224 B/op  20020978 allocs/op
-BenchmarkPool10
-BenchmarkPool10-6              1        1092621750 ns/op        232935976 B/op  20020126 allocs/op
-BenchmarkPool5
-BenchmarkPool5-6               1        1313762356 ns/op        232909576 B/op  20019824 allocs/op
-BenchmarkPureGo
-BenchmarkPureGo-6              1        2264417948 ns/op        237819960 B/op  20034677 allocs/op
-PASS
-ok  	github.com/getoutreach/gobox/pkg/async/pool	28.360s
-
-```
-
-# Insides
-
-- Currently structure utilize standard go channels that are more universal.
-- "Pool of workers" allow you to timeout without item being enqueued in opposite to pure "worker pool".
-
-## Example
+#### Old
 
 ```go
-package main
-
-import (
-	"fmt"
-	"context"
-	"fmt"
-	"github.com/getoutreach/gobox/pkg/async/pool"
+p := pool.New(ctx,
+  pool.ConstantSize(numOfWorkers),
 )
 
-func main() {
-	var (
-		concurrency = 5
-		items       = 10
-		sleepFor    = 5 * time.Millisecond
-	)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-
-    // Spawn pool of workers
-	p := pool.New(ctx,
-		pool.ConstantSize(concurrency),
-		pool.ResizeEvery(5*time.Minute),
-		pool.BufferLength(256),
-		pool.WaitWhenFull,
-	)
-	defer p.Close()
-
-    // Wrap it with timeout for schedule
-	scheduler = pool.WithTimeout(5 * time.Millisecond, p)
-
-    // Lets wait for items scheduled with this example
-	scheduler, wait := pool.WithWait(scheduler)
-
-	output := make(chan string, items)
-	now := time.Now()
-
-	for i := 0; i < items; i++ {
-		func(i int) {
-            // All input and output is captured by closure
-			scheduler.Schedule(ctx, async.Func(func(ctx context.Context) error {
-				if ctx.Err() != nil {
-					// It is very important to check the context error:
-					// - Given context might be done
-					// - Underlying buffered channel is full
-					// - Pool is in shutdown phase
-					return ctx.Err()
-				}
-				time.Sleep(sleepFor)
-				batchN := (time.Since(now) / (sleepFor))
-				output <- fmt.Sprintf("task_%d_%d", batchN, i)
-                // returned error is logged but not returned by Schedule function
-				return nil
-			})
-		}(i)
-	}
-	wait()
-
-	close(output)
-	for s := range output{
-		fmt.Println(s)
-	}
-	// Unordered output:
-	// task_1_3
-	// task_1_4
-	// task_1_0
-	// task_1_1
-	// task_1_2
-	// task_2_6
-	// task_2_9
-	// task_2_5
-	// task_2_7
-	// task_2_8
-}
+p.Schedule(ctx, async.Func(func(ctx context.Context) error {
+  // Do work
+}))
 ```
+
+#### New
+
+```go
+p := pool.New().WithContext(ctx).WithMaxGoroutines(numOfWorkers)
+
+// blocks if there is no available worker.
+p.Go(func(ctx context.Context) error {
+  // Do work
+})
+
+```
+
+#### Creating a Pool and waiting for it to finish (`pool.WithWait`)
+
+The `pool.WithWait` function is no longer necessary. Instead, the
+`pool.Pool` type has a `Wait` method that will block until all workers
+have finished.
+
+#### Old
+
+```go
+p := pool.New(ctx,
+  pool.ConstantSize(numOfWorkers),
+)
+
+var wait func()
+p, wait = pool.WithWait(p)
+
+go p.Schedule(ctx, async.Func(func(ctx context.Context) error {
+  // Do work
+}))
+
+wait()
+```
+
+#### New
+
+```go
+p := pool.New().WithContext(ctx).WithMaxGoroutines(numOfWorkers)
+
+go p.Go(func(ctx context.Context) error {
+  // Do work
+})
+
+p.Wait()
+```
+
+## Original README
+
+See [ORIGINAL_README.md](ORIGINAL_README.md) for the original README.

--- a/pkg/async/pool/pool.go
+++ b/pkg/async/pool/pool.go
@@ -33,7 +33,14 @@ func (of OptionFunc) Apply(opts *Options) {
 // SizeFunc tells the pool whether it should increase or decrease number of workers
 type SizeFunc func() int
 
-// ConstantSize provides
+// ConstantSize provides constant size for the pool.
+//
+// Deprecated: This library is being deprecated in favor of using
+// https://pkg.go.dev/github.com/sourcegraph/conc/pool instead. There is
+// no equivalent because calls to (*Pool).Go() will block if there are
+// no free workers. Control the size of the worker pool by calling
+// (*Pool).WithMaxGoroutines(). For more information, see the README:
+// https://github.com/getoutreach/gobox/tree/main/pkg/async/pool/README.md
 func ConstantSize(size int) OptionFunc {
 	return func(opts *Options) {
 		opts.Size = func() int {
@@ -131,6 +138,12 @@ type Pool struct {
 
 // New creates new instance of Pool and start goroutine that will spawn the workers
 // Call Close() to release pool resource
+//
+// Deprecated: This library is being deprecated in favor of using
+// https://pkg.go.dev/github.com/sourcegraph/conc/pool instead. Use
+// (*Pool).New().WithContext() instead. Replace calls to Schedule with
+// (*Pool).Go(). For more information, see the README:
+// https://github.com/getoutreach/gobox/tree/main/pkg/async/pool/README.md
 func New(ctx context.Context, options ...Option) *Pool {
 	// default values
 	var opts = &Options{
@@ -238,6 +251,12 @@ func (p *Pool) Close() {
 // - When item gets successfully scheduled and withdrawn by worker
 // - When the given context is Done and item is not scheduled (Timeout, buffered queue full)
 // - When pool is in shutdown phase.
+//
+// Deprecated: This library is being deprecated in favor of using
+// https://pkg.go.dev/github.com/sourcegraph/conc/pool instead. Replace
+// calls to Schedule with (*Pool).Go(). For more information, see the
+// README:
+// https://github.com/getoutreach/gobox/tree/main/pkg/async/pool/README.md
 func (p *Pool) Schedule(ctx context.Context, r async.Runner) error {
 	// Check whether pool is alive
 	if p.context.Err() != nil {
@@ -276,13 +295,28 @@ type loggingScheduler struct {
 	Name  string
 }
 
+// Schedule task for processing in the pool with logging for each item
+// being scheduled and executed.
+//
+// Deprecated: This library is being deprecated in favor of using
+// https://pkg.go.dev/github.com/sourcegraph/conc/pool instead. There is
+// no replacement for this function. Instead, log on each item when
+// calling (*Pool).Go(). For more information, see the README:
+// https://github.com/getoutreach/gobox/tree/main/pkg/async/pool/README.md
 func (w *loggingScheduler) Schedule(ctx context.Context, r async.Runner) error {
 	return w.log(ctx, w.Inner.Schedule(ctx, async.Func(func(ctx context.Context) error {
 		return w.log(ctx, r.Run(ctx))
 	})))
 }
 
-// WithLogging creates a scheduler which logs the errors returned from the scheduling as well as executing phase
+// WithLogging creates a scheduler which logs the errors returned from
+// the scheduling as well as executing phase.
+//
+// Deprecated: This library is being deprecated in favor of using
+// https://pkg.go.dev/github.com/sourcegraph/conc/pool instead. There is
+// no replacement for this function. Instead, log on each item when
+// calling (*Pool).Go(). For more information, see the README:
+// https://github.com/getoutreach/gobox/tree/main/pkg/async/pool/README.md
 func WithLogging(name string, s Scheduler) Scheduler {
 	return &loggingScheduler{Name: name, Inner: s}
 }

--- a/pkg/async/pool/scheduler.go
+++ b/pkg/async/pool/scheduler.go
@@ -18,5 +18,11 @@ func (sf SchedulerFunc) Schedule(ctx context.Context, r async.Runner) error {
 
 type Scheduler interface {
 	// Schedule task for processing in the pool
+	//
+	// Deprecated: This library is being deprecated in favor of using
+	// https://pkg.go.dev/github.com/sourcegraph/conc/pool instead.
+	// Replaces calls to Schedule with (*Pool).Go().  For more information,
+	// see the README:
+	// https://github.com/getoutreach/gobox/tree/main/pkg/async/pool/README.md
 	Schedule(ctx context.Context, r async.Runner) error
 }

--- a/pkg/async/pool/timeout.go
+++ b/pkg/async/pool/timeout.go
@@ -11,7 +11,14 @@ import (
 	"github.com/getoutreach/gobox/pkg/async"
 )
 
-// WithTimeout creates enqueuer that cancel enqueueing after given timeout
+// WithTimeout creates enqueuer that cancel enqueueing after given
+// timeout
+//
+// Deprecated: This library is being deprecated in favor of using
+// https://pkg.go.dev/github.com/sourcegraph/conc/pool instead. There is
+// no equivalent to this function in the new library. For more
+// information, see the README:
+// https://github.com/getoutreach/gobox/tree/main/pkg/async/pool/README.md
 func WithTimeout(timeout time.Duration, scheduler Scheduler) Scheduler {
 	return SchedulerFunc(func(ctx context.Context, r async.Runner) error {
 		ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/pkg/async/pool/wait.go
+++ b/pkg/async/pool/wait.go
@@ -27,6 +27,14 @@ func (w *Wait) Schedule(ctx context.Context, r async.Runner) error {
 	}))
 }
 
+// WithWait wraps a scheduler and returns a new scheduler and a function
+// that blocks until all scheduled tasks are processed or have failed to
+// enqueue.
+//
+// Deprecated: This library is being deprecated in favor of using
+// https://pkg.go.dev/github.com/sourcegraph/conc/pool instead. Use
+// (*Pool).Wait() instead. For more information, see the README:
+// https://github.com/getoutreach/gobox/tree/main/pkg/async/pool/README.md
 func WithWait(s Scheduler) (scheduler Scheduler, wait func()) {
 	w := &Wait{Scheduler: s}
 	return w, func() {


### PR DESCRIPTION
Deprecates the major methods in `async/pool` in favor of using
`github.com/sourcegraph/conc/pool` instead. The `async/pool` has had
usability issues for a long time now, namely hard to use `Wait()` as
well as almost impossible to get errors out of. The `conc/pool` library
is a much better, more actively maintained libary.

Included is a new `README.md` with instructions on how to migrate all
usecases I could discern from across the `getoutreach` organization.

The main change here is the removal of bufferred pools of work items
that could be dynamically resized as well as rejected if there was no
room. I could only find one repo, `mailroomapi`, that used this
functionality. It is likely that the block until accepted behaviour will
be more acceptable to this service, but also I don't feel that warrants
the additional overhead/code duplication that we own here today.
