### PR TITLE
docs(README): update links and some wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Context is often abused for thread-local state. There are very few legitimate us
 
 ### Do not use fmt.PrintXXX or the standard log package
 
-Prefer the [gobox log](https://github.com/getoutreach/gobox/blob/master/docs/log.md) package. This logs data in a structured format suitable for outreach Go services.
+Prefer the [gobox log](https://pkg.go.dev/github.com/getoutreach/gobox/pkg/log) package. This logs data in a structured format suitable for outreach Go services.
 
 ### Do not use non-literal messages with log
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Do not use the following pattern:
 The first arg of `log.XXX` calls should be a literal string so we can
 quickly find out where a log message comes from. The rest of the args
 can hold any structured data we want. The
-[events](https://github.com/getoutreach/gobox/blob/master/docs/events.md)
+[events](https://pkg.go.dev/github.com/getoutreach/gobox/pkg/events)
 package exposes a few common logging structures.
 
 ### Use code generation for stringifying enums

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- <</Stencil::Block>> -->
 
-A collection of libraries that are useful for implementing Go services, libraries, and more.
+A collection of useful libraries for implementing Go services, libraries, and more.
 
 ## Contributing
 
@@ -29,15 +29,15 @@ comments](https://github.com/golang/go/wiki/CodeReviewComments),
 
 ### Log errors with events.NewErrorInfo
 
-When logging errors, use `log.Debug(ctx, "some debug event", events.NewErrorInfo(err))` instead of using `log.F{"error": err}`. [NewErrorInfo](https://github.com/getoutreach/gobox/blob/master/docs/events.md) logs errors using outreach naming conventions and also takes care of logging stack traces.
+When logging errors, use `log.Debug(ctx, "some debug event", events.NewErrorInfo(err))` instead of using `log.F{"error": err}`. [NewErrorInfo](https://pkg.go.dev/github.com/getoutreach/gobox/pkg/events) logs errors using outreach naming conventions and logs stack traces.
 
 ### Do not use context.WithValue
 
-Context is often abused for thread local state. There are very few legitimate uses for this ([tracing](https://github.com/getoutreach/gobox/blob/master/docs/trace.md) is one of those).
+Context is often abused for thread-local state. There are very few legitimate uses for this ([tracing](https://pkg.go.dev/github.com/getoutreach/gobox/pkg/trace) is one of those).
 
 ### Do not use fmt.PrintXXX or the standard log package
 
-Prefer the [gobox log](https://github.com/getoutreach/gobox/blob/master/docs/log.md) package. This logs data in structured format suitable for outreach go services.
+Prefer the [gobox log](https://github.com/getoutreach/gobox/blob/master/docs/log.md) package. This logs data in a structured format suitable for outreach Go services.
 
 ### Do not use non-literal messages with log
 


### PR DESCRIPTION
Updated some leftover links to point to pkg.go.dev, their equivalent today.

Slightly cleaned up some words.
