### PR TITLE
feat: add capability to have a status code for client canceled.

### DIFF
--- a/pkg/statuscodes/statuscode_string.go
+++ b/pkg/statuscodes/statuscode_string.go
@@ -15,6 +15,7 @@ func _() {
 	_ = x[NotFound-703]
 	_ = x[Conflict-704]
 	_ = x[RateLimited-705]
+	_ = x[ClientCanceled-706]
 	_ = x[InternalServerError-800]
 	_ = x[NotImplemented-801]
 	_ = x[Unavailable-802]
@@ -23,12 +24,12 @@ func _() {
 
 const (
 	_StatusCode_name_0 = "OK"
-	_StatusCode_name_1 = "BadRequestUnauthorizedForbiddenNotFoundConflictRateLimited"
+	_StatusCode_name_1 = "BadRequestUnauthorizedForbiddenNotFoundConflictRateLimitedClientCanceled"
 	_StatusCode_name_2 = "InternalServerErrorNotImplementedUnavailableUnknownError"
 )
 
 var (
-	_StatusCode_index_1 = [...]uint8{0, 10, 22, 31, 39, 47, 58}
+	_StatusCode_index_1 = [...]uint8{0, 10, 22, 31, 39, 47, 58, 72}
 	_StatusCode_index_2 = [...]uint8{0, 19, 33, 44, 56}
 )
 
@@ -36,7 +37,7 @@ func (i StatusCode) String() string {
 	switch {
 	case i == 600:
 		return _StatusCode_name_0
-	case 700 <= i && i <= 705:
+	case 700 <= i && i <= 706:
 		i -= 700
 		return _StatusCode_name_1[_StatusCode_index_1[i]:_StatusCode_index_1[i+1]]
 	case 800 <= i && i <= 803:

--- a/pkg/statuscodes/statuscode_string.go
+++ b/pkg/statuscodes/statuscode_string.go
@@ -15,7 +15,7 @@ func _() {
 	_ = x[NotFound-703]
 	_ = x[Conflict-704]
 	_ = x[RateLimited-705]
-	_ = x[ClientCanceled-706]
+	_ = x[ClientConnectionSevered-706]
 	_ = x[InternalServerError-800]
 	_ = x[NotImplemented-801]
 	_ = x[Unavailable-802]
@@ -24,12 +24,12 @@ func _() {
 
 const (
 	_StatusCode_name_0 = "OK"
-	_StatusCode_name_1 = "BadRequestUnauthorizedForbiddenNotFoundConflictRateLimitedClientCanceled"
+	_StatusCode_name_1 = "BadRequestUnauthorizedForbiddenNotFoundConflictRateLimitedClientConnectionSevered"
 	_StatusCode_name_2 = "InternalServerErrorNotImplementedUnavailableUnknownError"
 )
 
 var (
-	_StatusCode_index_1 = [...]uint8{0, 10, 22, 31, 39, 47, 58, 72}
+	_StatusCode_index_1 = [...]uint8{0, 10, 22, 31, 39, 47, 58, 81}
 	_StatusCode_index_2 = [...]uint8{0, 19, 33, 44, 56}
 )
 

--- a/pkg/statuscodes/statuscodes.go
+++ b/pkg/statuscodes/statuscodes.go
@@ -47,6 +47,10 @@ const (
 	// are flooding the server.  It is expected that the client will back off for some duration and then try again.
 	// Well-behaved services will even return an expected duration for the client to retry-after.
 	RateLimited StatusCode = 705
+	// ClientCanceled is for when the client has canceled the request, and the server has not yet started processing.
+	// It is expectedc that sometimes the client will simply have a canceled request and no server request will have
+	// been made.
+	ClientCanceled StatusCode = 706
 
 	// The 800-swath is for Server-caused error responses
 	// InternalServerError is for when something otherwise uncategorizable has blown up inside the service logic.
@@ -122,6 +126,8 @@ func FromString(s string) (StatusCode, bool) {
 		return Conflict, true
 	case RateLimited.String():
 		return RateLimited, true
+	case ClientCanceled.String():
+		return ClientCanceled, true
 	case InternalServerError.String():
 		return InternalServerError, true
 	case NotImplemented.String():

--- a/pkg/statuscodes/statuscodes.go
+++ b/pkg/statuscodes/statuscodes.go
@@ -47,10 +47,10 @@ const (
 	// are flooding the server.  It is expected that the client will back off for some duration and then try again.
 	// Well-behaved services will even return an expected duration for the client to retry-after.
 	RateLimited StatusCode = 705
-	// ClientCanceled is for when the client has canceled the request, and the server has not yet started processing.
-	// It is expected that sometimes the client will simply have a canceled request and no server request will have
-	// been made.
-	ClientCanceled StatusCode = 706
+	// ClientConnectionSevered is for when the client was going to make a request but the connection has been severed.
+	// This can occur when a service is using a client to connect to a downstream service. When making the request
+	// it is not sent because the connection has been severed.
+	ClientConnectionSevered StatusCode = 706
 
 	// The 800-swath is for Server-caused error responses
 	// InternalServerError is for when something otherwise uncategorizable has blown up inside the service logic.
@@ -126,8 +126,8 @@ func FromString(s string) (StatusCode, bool) {
 		return Conflict, true
 	case RateLimited.String():
 		return RateLimited, true
-	case ClientCanceled.String():
-		return ClientCanceled, true
+	case ClientConnectionSevered.String():
+		return ClientConnectionSevered, true
 	case InternalServerError.String():
 		return InternalServerError, true
 	case NotImplemented.String():

--- a/pkg/statuscodes/statuscodes.go
+++ b/pkg/statuscodes/statuscodes.go
@@ -48,7 +48,7 @@ const (
 	// Well-behaved services will even return an expected duration for the client to retry-after.
 	RateLimited StatusCode = 705
 	// ClientCanceled is for when the client has canceled the request, and the server has not yet started processing.
-	// It is expectedc that sometimes the client will simply have a canceled request and no server request will have
+	// It is expected that sometimes the client will simply have a canceled request and no server request will have
 	// been made.
 	ClientCanceled StatusCode = 706
 

--- a/pkg/statuscodes/statuscodes_test.go
+++ b/pkg/statuscodes/statuscodes_test.go
@@ -11,7 +11,7 @@ func TestStatusCodeUnmarshalText(t *testing.T) {
 		NotFound,
 		Conflict,
 		RateLimited,
-		ClientCanceled,
+		ClientConnectionSevered,
 		InternalServerError,
 		NotImplemented,
 		Unavailable,

--- a/pkg/statuscodes/statuscodes_test.go
+++ b/pkg/statuscodes/statuscodes_test.go
@@ -11,6 +11,7 @@ func TestStatusCodeUnmarshalText(t *testing.T) {
 		NotFound,
 		Conflict,
 		RateLimited,
+		ClientCanceled,
 		InternalServerError,
 		NotImplemented,
 		Unavailable,


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This happens when a server already cancels a request. This will enable better metrics tracking. There were cases where due to a context being canceled an InternalServerError returned. This would cause alerts to trigger when in fact the only issue was that the context was canceled.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[STAR-1788]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
This was an issue that was happening for marathon. By the time the server goes to make the request the context has been canceled. At this point its best to simply return "ClientCanceled"

More discussion came from this slack thread.
https://outreach-hq.slack.com/archives/CN9MU7GLW/p1691689393028399

This PR is simply the first part of what was already discussed.
<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[STAR-1788]: https://outreach-io.atlassian.net/browse/STAR-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ