### PR TITLE
feat(aws): add support for refreshing AWS creds via okta-aws-cli

### DIFF
--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -37,6 +37,12 @@ type AWSConfig struct {
 	// DefaultProfile is the default profile to use when communcating
 	// with AWS.
 	DefaultProfile string `yaml:"defaultProfile"`
+
+	// RefreshMethod is the CLI used to refresh AWS credentials.
+	// Known values:
+	// * saml2aws (default)
+	// * okta-aws-cli
+	RefreshMethod string `yaml:"refreshMethod"`
 }
 
 type DeveloperEnvironmentConfig struct {

--- a/pkg/cli/aws/aws.go
+++ b/pkg/cli/aws/aws.go
@@ -141,8 +141,7 @@ func refreshCredsViaOktaAWSCLI(ctx context.Context, copts *CredentialOptions, re
 		copts.Log.WithField("reason", reason).Info("Obtaining AWS credentials via Okta")
 	}
 
-	//nolint:gosec // Why: What other option do I have
-	cmd := exec.CommandContext(ctx,
+	err := runCmd(ctx,
 		"okta-aws-cli",
 		"--open-browser",
 		"--write-aws-credentials",
@@ -151,10 +150,7 @@ func refreshCredsViaOktaAWSCLI(ctx context.Context, copts *CredentialOptions, re
 		"--aws-iam-role",
 		copts.Role,
 	)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	cmd.Stdin = os.Stdin
-	if err := cmd.Run(); err != nil {
+	if err != nil {
 		return errors.Wrap(err, "failed to refresh AWS credentials via okta-aws-cli")
 	}
 
@@ -170,14 +166,18 @@ func refreshCredsViaSaml2aws(ctx context.Context, copts *CredentialOptions, reas
 		copts.Log.WithField("reason", reason).Info("Obtaining AWS credentials via Okta")
 	}
 
-	//nolint:gosec // Why: What other option do I have
-	cmd := exec.CommandContext(ctx, "saml2aws", "login", "--profile", copts.Profile, "--role", copts.Role, "--force")
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	cmd.Stdin = os.Stdin
-	if err := cmd.Run(); err != nil {
+	err := runCmd(ctx, "saml2aws", "login", "--profile", copts.Profile, "--role", copts.Role, "--force")
+	if err != nil {
 		return errors.Wrap(err, "failed to refresh AWS credentials via saml2aws")
 	}
 
 	return nil
+}
+
+func runCmd(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
 }


### PR DESCRIPTION
## What this PR does / why we need it

Allows support for an additional AWS credential refresh method to the existing `saml2aws` support, via `okta-aws-cli`. The refresh method is toggled via the box configuration `.config.aws.refreshMethod`.

## Jira ID

[DT-3912]