### PR TITLE
feat(aws): add interactive role selection; MFA for saml2aws

### DIFF
--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -43,6 +43,16 @@ type AWSConfig struct {
 	// * saml2aws (default)
 	// * okta-aws-cli
 	RefreshMethod string `yaml:"refreshMethod"`
+
+	Okta OktaConfig `yaml:"okta"`
+}
+
+// OktaConfig is Okta-related configuration for AWS authorization.
+type OktaConfig struct {
+	// DefaultMFA is the default MFA type to use when using the
+	// saml2aws refresh method and outputting in the credential
+	// provider format.
+	DefaultMFA string `yaml:"defaultMFA"`
 }
 
 type DeveloperEnvironmentConfig struct {

--- a/pkg/cli/aws/aws.go
+++ b/pkg/cli/aws/aws.go
@@ -74,6 +74,9 @@ type AuthorizeCredentialsOptions struct {
 	DryRun bool
 	// If Force is true, always overwrite the existing AWS credentials.
 	Force bool
+	// If MFA is not empty and the Output type is credential provider,
+	// set the MFA type when the selected authorization tool supports it.
+	MFA string
 	// If Output is not empty, print the specified format to STDOUT
 	// instead of writing to the AWS credentials file.
 	Output CredentialsOutput
@@ -235,6 +238,9 @@ func refreshCredsViaSaml2aws(ctx context.Context, copts *CredentialOptions, acop
 
 	if acopts.Output == OutputCredentialProvider {
 		args = append(args, "--credential-process")
+		if acopts.MFA != "" {
+			args = append([]string{"--mfa", acopts.MFA}, args...)
+		}
 	}
 
 	if acopts.DryRun {

--- a/pkg/cli/aws/aws.go
+++ b/pkg/cli/aws/aws.go
@@ -170,8 +170,10 @@ func EnsureValidCredentials(ctx context.Context, copts *CredentialOptions) error
 // refreshCredsViaOktaAWSCLI refreshes the AWS credentials in the AWS
 // credentials file via the okta-aws-cli CLI tool.
 func refreshCredsViaOktaAWSCLI(ctx context.Context, copts *CredentialOptions, acopts *AuthorizeCredentialsOptions, reason string) error {
-	if _, err := exec.LookPath("okta-aws-cli"); err != nil {
-		return fmt.Errorf("failed to find okta-aws-cli in PATH")
+	if !acopts.DryRun {
+		if _, err := exec.LookPath("okta-aws-cli"); err != nil {
+			return fmt.Errorf("failed to find okta-aws-cli in PATH")
+		}
 	}
 
 	if copts.Log != nil {
@@ -210,8 +212,10 @@ func refreshCredsViaOktaAWSCLI(ctx context.Context, copts *CredentialOptions, ac
 // refreshCredsViaSaml2aws refreshes the AWS credentials in the AWS
 // credentials file via the saml2aws CLI tool.
 func refreshCredsViaSaml2aws(ctx context.Context, copts *CredentialOptions, acopts *AuthorizeCredentialsOptions, reason string) error {
-	if _, err := exec.LookPath("saml2aws"); err != nil {
-		return fmt.Errorf("failed to find saml2aws, please run orc setup")
+	if !acopts.DryRun {
+		if _, err := exec.LookPath("saml2aws"); err != nil {
+			return fmt.Errorf("failed to find saml2aws, please run orc setup")
+		}
 	}
 
 	if copts.Log != nil {

--- a/pkg/cli/aws/aws.go
+++ b/pkg/cli/aws/aws.go
@@ -50,6 +50,12 @@ func DefaultCredentialOptions() *CredentialOptions {
 	}
 }
 
+// chooseRoleInteractively determines whether the credential tool
+// needs to choose an IAM role interactively.
+func (c *CredentialOptions) chooseRoleInteractively() bool {
+	return c.Role == ""
+}
+
 type CredentialsOutput string
 
 // Possible CredentialsOutput values.
@@ -58,9 +64,6 @@ const (
 	// CLI used needs to output credential provider compliant JSON.
 	// nolint: gosec // Why: These aren't credentials.
 	OutputCredentialProvider CredentialsOutput = "credential-provider"
-	// RoleInteractive is the magic value used to indicate that the
-	// user wants to interactively select a role.
-	RoleInteractive = "interactive"
 )
 
 // AuthorizeCredentialsOptions are optional arguments for the
@@ -91,11 +94,6 @@ func assumedToRole(assumedRole string) string {
 // needsRefresh determines if AWS authentication needs to be refreshed
 // or setup.
 func needsRefresh(copts *CredentialOptions) (needsNewCreds bool, reason string) {
-	if copts.Role == RoleInteractive {
-		// Assume that if the caller is explicitly asking to select
-		// the role interactively, that they want to refresh authentication.
-		return true, "Refreshing AWS credentials since we are interactively selecting a role"
-	}
 	if creds, err := awsconfig.NewSharedCredentials(copts.Profile, copts.FileName).Load(); err == nil {
 		// Check, via the principal_arn, if the creds match the role we want
 		if creds.PrincipalARN != "" && assumedToRole(creds.PrincipalARN) != copts.Role {
@@ -187,7 +185,7 @@ func refreshCredsViaOktaAWSCLI(ctx context.Context, copts *CredentialOptions, ac
 		copts.Profile,
 	}
 
-	if copts.Role != RoleInteractive {
+	if !copts.chooseRoleInteractively() {
 		args = append(args, "--aws-iam-role", copts.Role)
 	}
 
@@ -227,7 +225,7 @@ func refreshCredsViaSaml2aws(ctx context.Context, copts *CredentialOptions, acop
 		"--force",
 	}
 
-	if copts.Role != RoleInteractive {
+	if !copts.chooseRoleInteractively() {
 		args = append(args, "--role", copts.Role)
 	}
 

--- a/pkg/cli/aws/aws.go
+++ b/pkg/cli/aws/aws.go
@@ -182,7 +182,6 @@ func refreshCredsViaOktaAWSCLI(ctx context.Context, copts *CredentialOptions, ac
 
 	args := []string{
 		"--open-browser",
-		"--write-aws-credentials",
 		"--cache-access-token",
 		"--profile",
 		copts.Profile,
@@ -194,6 +193,8 @@ func refreshCredsViaOktaAWSCLI(ctx context.Context, copts *CredentialOptions, ac
 
 	if acopts.Output == OutputCredentialProvider {
 		args = append(args, "--format", string(OutputCredentialProvider))
+	} else {
+		args = append(args, "--write-aws-credentials")
 	}
 
 	if acopts.DryRun {

--- a/pkg/cli/aws/aws_test.go
+++ b/pkg/cli/aws/aws_test.go
@@ -56,6 +56,14 @@ func Test_needsRefresh(t *testing.T) {
 		wantReason          string
 	}{
 		{
+			name: "should refresh when selecting a role interactively",
+			args: args{copts: &CredentialOptions{
+				Role: RoleInteractive,
+			}},
+			wantNeedsNewCreds: true,
+			wantReason:        "Refreshing AWS credentials since we are interactively selecting a role",
+		},
+		{
 			name: "should refresh when file doesn't exist",
 			args: args{copts: &CredentialOptions{
 				FileName: "i/do/not/exist",

--- a/pkg/cli/aws/aws_test.go
+++ b/pkg/cli/aws/aws_test.go
@@ -1,11 +1,13 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 )
 
@@ -114,4 +116,15 @@ x_security_token_expires = 2006-01-02T15:04:05+07:00`,
 			}
 		})
 	}
+}
+
+func Test_AuthorizeCredentials(t *testing.T) {
+	copts := &CredentialOptions{
+		Log: logrus.New(),
+	}
+	acopts := &AuthorizeCredentialsOptions{
+		DryRun: true,
+	}
+	err := AuthorizeCredentials(context.Background(), copts, acopts)
+	assert.NilError(t, err)
 }

--- a/pkg/cli/aws/aws_test.go
+++ b/pkg/cli/aws/aws_test.go
@@ -1,13 +1,11 @@
 package aws
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 )
 
@@ -124,15 +122,4 @@ x_security_token_expires = 2006-01-02T15:04:05+07:00`,
 			}
 		})
 	}
-}
-
-func Test_AuthorizeCredentials(t *testing.T) {
-	copts := &CredentialOptions{
-		Log: logrus.New(),
-	}
-	acopts := &AuthorizeCredentialsOptions{
-		DryRun: true,
-	}
-	err := AuthorizeCredentials(context.Background(), copts, acopts)
-	assert.NilError(t, err)
 }

--- a/pkg/cli/aws/aws_test.go
+++ b/pkg/cli/aws/aws_test.go
@@ -54,14 +54,6 @@ func Test_needsRefresh(t *testing.T) {
 		wantReason          string
 	}{
 		{
-			name: "should refresh when selecting a role interactively",
-			args: args{copts: &CredentialOptions{
-				Role: RoleInteractive,
-			}},
-			wantNeedsNewCreds: true,
-			wantReason:        "Refreshing AWS credentials since we are interactively selecting a role",
-		},
-		{
 			name: "should refresh when file doesn't exist",
 			args: args{copts: &CredentialOptions{
 				FileName: "i/do/not/exist",


### PR DESCRIPTION
## What this PR does / why we need it

If `role` is empty, omit the IAM role from the respective CLIs and make them set the role interactively.

## Jira ID

[DT-3999]

## Notes for your reviewers

Adds some tests for `refreshCredsViaOktaAWSCLI`.

[DT-3999]: https://outreach-io.atlassian.net/browse/DT-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ