### PR TITLE
fix: DT-4023 Fix tracing.ForceSample + SampleRate

### DIFF
--- a/pkg/trace/logfile.go
+++ b/pkg/trace/logfile.go
@@ -57,7 +57,6 @@ func NewLogFileTracer(ctx context.Context, serviceName string, config *Config) (
 		sdktrace.WithResource(r),
 		sdktrace.WithSpanProcessor(Annotator{
 			globalTags: tracer.GlobalTags,
-			sampleRate: 1,
 		}),
 	}
 

--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -35,7 +35,6 @@ type otelTracer struct {
 	sync.Once
 	serviceName    string
 	tracerProvider *sdktrace.TracerProvider
-	force          bool
 }
 
 // NewOtelTracer creates and initializes a new otel tracer.
@@ -51,7 +50,6 @@ func NewOtelTracer(ctx context.Context, serviceName string, config *Config) (tra
 // Annotator is a SpanProcessor that adds service-level tags on every span
 type Annotator struct {
 	globalTags GlobalTags
-	sampleRate int64
 }
 
 func (a Annotator) OnStart(_ context.Context, s sdktrace.ReadWriteSpan) {
@@ -59,7 +57,6 @@ func (a Annotator) OnStart(_ context.Context, s sdktrace.ReadWriteSpan) {
 		s.SetAttributes(attribute.String(key, fmt.Sprintf("%v", value)))
 	}
 
-	s.SetAttributes(attribute.Int64("SampleRate", a.sampleRate))
 	app.Info().MarshalLog(setf)
 	a.globalTags.MarshalLog(setf)
 }
@@ -133,7 +130,6 @@ func (t *otelTracer) initTracer(ctx context.Context, serviceName string) error {
 		sdktrace.WithSampler(forceSample(uint(100 / t.Otel.SamplePercent))),
 		sdktrace.WithSpanProcessor(Annotator{
 			globalTags: t.GlobalTags,
-			sampleRate: int64(100 / t.Otel.SamplePercent),
 		}),
 	}
 
@@ -402,12 +398,4 @@ func (t *otelTracer) spanID(ctx context.Context) string {
 // OpenTelemetry automatically handle adding parentID to traces
 func (t *otelTracer) parentID(ctx context.Context) string {
 	return ""
-}
-
-func (t *otelTracer) setForce(force bool) {
-	t.force = force
-}
-
-func (t *otelTracer) isForce() bool {
-	return t.force
 }

--- a/pkg/trace/propagation.go
+++ b/pkg/trace/propagation.go
@@ -44,7 +44,7 @@ func (rt roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		r.Header[k] = v
 	}
 
-	if defaultTracer.isForce() {
+	if isTracingForced(r.Context()) {
 		r.Header.Set(HeaderForceTracing, "true")
 	}
 
@@ -73,6 +73,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if force != "" {
 		startOptions = oteltrace.WithAttributes(attribute.String(fieldForceTrace, force))
 		handler = otelhttp.NewHandler(h.handler, h.operation, otelhttp.WithSpanOptions(startOptions))
+		r = r.WithContext(forceTracing(r.Context()))
 	}
 
 	handler.ServeHTTP(w, r)

--- a/pkg/trace/propagation_test.go
+++ b/pkg/trace/propagation_test.go
@@ -90,7 +90,7 @@ func TestForceTracingByHeader(t *testing.T) {
 			"attributes.timing.service_time":       differs.FloatRange(0, 30),
 			"attributes.timing.total_time":         differs.FloatRange(0, 30),
 			"attributes.timing.wait_time":          differs.FloatRange(0, 30),
-			"SampleRate":                           int64(1000),
+			"SampleRate":                           int64(1),
 		},
 	}
 
@@ -125,7 +125,7 @@ func TestHeadersForceTracingByHeader(t *testing.T) {
 
 	expected := []map[string]interface{}{
 		{
-			"SampleRate":              int64(1000),
+			"SampleRate":              int64(1),
 			"name":                    "inner",
 			"spanContext.traceID":     traceID,
 			"spanContext.spanID":      differs.AnyString(),
@@ -142,7 +142,7 @@ func TestHeadersForceTracingByHeader(t *testing.T) {
 			"attributes.service_name": "gobox",
 		},
 		{
-			"SampleRate":              int64(1000),
+			"SampleRate":              int64(1),
 			"name":                    "trace-test",
 			"spanContext.traceID":     traceID,
 			"spanContext.spanID":      rootID,
@@ -238,7 +238,7 @@ func TestForceTracing(t *testing.T) {
 			"attributes.timing.service_time":       differs.FloatRange(0, 30),
 			"attributes.timing.total_time":         differs.FloatRange(0, 30),
 			"attributes.timing.wait_time":          differs.FloatRange(0, 30),
-			"SampleRate":                           int64(1000),
+			"SampleRate":                           int64(1),
 		},
 		{
 			"name":                    "trace-test",
@@ -255,7 +255,7 @@ func TestForceTracing(t *testing.T) {
 			"attributes.app.name":     "gobox",
 			"attributes.service_name": "gobox",
 			"attributes.app.version":  "testing",
-			"SampleRate":              int64(1000),
+			"SampleRate":              int64(1),
 		},
 	}
 

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -48,10 +48,6 @@ type tracer interface {
 
 	newHandler(handler http.Handler, operation string) http.Handler
 
-	isForce() bool
-
-	setForce(force bool)
-
 	toHeaders(ctx context.Context) map[string][]string
 
 	contextFromHeaders(ctx context.Context, hdrs map[string][]string) context.Context


### PR DESCRIPTION
[DT-4023](https://outreach-io.atlassian.net/browse/DT-4023)

Updates the implementation of `trace.ForceTracing(ctx)` such that it has
an effect only when its returned `ctx` is used.  The modified `ctx` will
always sample any spans associated with it.  Any requests made with this
`ctx` will send an `X-Force-Trace` header to the receiving service.
However, there will be no impacts outside of this particular `ctx`.

Previously, this method would set an effectively process-global flag and
enable force-trace behaviors process-wide.  This is not what the
function signature suggests it does and probably not what its callers
would expect.

Since we're poking at the `otelForceSampler` code anyway, updates the
decisions returned by `ShouldSample` to include a proper "SampleRate"
attribute.  This will let Honeycomb know what kind of dice roll (if any)
led to this trace being sampled, so it can adjust its estimated counts
accordingly.

[DT-4023]: https://outreach-io.atlassian.net/browse/DT-4023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ