### PR TITLE
feat: DT-4029: Disable call info logging default

### DIFF
--- a/internal/call/option.go
+++ b/internal/call/option.go
@@ -7,9 +7,10 @@ type Option func(c *Info)
 
 // Options contains options for all tracing calls.
 type Options struct {
-	// DisableInfoLogging turns off per-call info logging if set to true. If false, every successful
-	// (statuscodes.CategoryOK) call will have an Info line emitted.
-	DisableInfoLogging bool
+	// EnableInfoLogging turns on per-call info logging if set to true. If
+	// true, every successful (statuscodes.CategoryOK) call will have an
+	// Info line emitted.  Otherwise, it is omitted.
+	EnableInfoLogging bool
 }
 
 // MarshalLog is defined for being compliant with trace.StartCall contract

--- a/pkg/trace/call_option.go
+++ b/pkg/trace/call_option.go
@@ -62,13 +62,30 @@ func WithCallOptions(ctx context.Context, opts CallOptions) {
 	callTracker.Info(ctx).Opts = call.Options(opts)
 }
 
-// WithInfoLoggingDisabled disables info logging on the current call
+// WithInfoLoggingDisabled disables info logging on the current call.
+//
+// Note that the default behavior is configurable.  If the info logs were
+// already disabled by default, this will be a no-op.
 //
 // Example:
 //
 //	ctx = trace.StartCall(ctx, "http", trace.WithInfoLoggingDisabled())
 func WithInfoLoggingDisabled() call.Option {
 	return func(c *call.Info) {
-		c.Opts.DisableInfoLogging = true
+		c.Opts.EnableInfoLogging = false
+	}
+}
+
+// WithInfoLoggingEnabled enables info logging on the current call
+//
+// Note that the default behavior is configurable.  If the info logs were
+// already enabled by default, this will be a no-op.
+//
+// Example:
+//
+//	ctx = trace.StartCall(ctx, "http", trace.WithInfoLoggingEnabled())
+func WithInfoLoggingEnabled() call.Option {
+	return func(c *call.Info) {
+		c.Opts.EnableInfoLogging = true
 	}
 }

--- a/pkg/trace/config.go
+++ b/pkg/trace/config.go
@@ -14,6 +14,12 @@ type Config struct {
 	Otel       `yaml:"OpenTelemetry"`
 	LogFile    LogFile `yaml:"LogFile"`
 	GlobalTags `yaml:"GlobalTags,omitempty"`
+
+	// LogCallByDefault determines info logs for non-error instances of
+	// `trace.StartCall`.  The behavior can be overridden by providing
+	// explicit options to specific `trace.StartCall` invocations.  A
+	// `trace.StartCall` that ends in an error will always be logged.
+	LogCallsByDefault bool `yaml:"LogCallsByDefault"`
 }
 
 // GlobalTags are tags that get included with every span

--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -179,6 +179,7 @@ func (t *otelTracer) closeTracer(ctx context.Context) {
 	}
 
 	t.tracerProvider.ForceFlush(ctx)
+
 	err := t.tracerProvider.Shutdown(ctx)
 	if err != nil {
 		log.Error(ctx, "Unable to stop otel tracer", events.NewErrorInfo(err))

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -165,6 +165,8 @@ func setDefaultTracer(serviceName string) error {
 		}
 	}
 
+	logCallsByDefault = config.LogCallsByDefault
+
 	return nil
 }
 
@@ -188,6 +190,12 @@ func CloseTracer(ctx context.Context) {
 	if defaultTracer == nil {
 		return
 	}
+
+	// In a nod to tests, reset the logCallsByDefault flag to its default
+	// state.  This ensures the `trace.CloseTracer` call at the end of a
+	// tracetest run cleans up any non-default values it created when it was
+	// initialized.
+	logCallsByDefault = false
 
 	defaultTracer.closeTracer(ctx)
 }


### PR DESCRIPTION
[DT-4029](https://outreach-io.atlassian.net/browse/DT-4029)

Disables the info logs that would previously occur as part of a
`trace.StartCall`'s succesful completion.  Calls that end in errors have
been and will continue to be logged.

Adds a boolean config option to `trace.yaml` so that services can opt
back in to the old behavior.  We don't want services to fear upgrading
to this version of gobox; this flag will let them upgrade without
experiencing an unpleasant behavior change.

Adds a new call option to explicitly enable info logs for particular
instances of `trace.StartCall`.  We hope that folks that rely on these
logs will rely on this more targeted approach to meet their needs,
rather than using the service-wide `trace.yaml` opt-out.

If you would like to keep your service on the more verbose behavior,
add the following snippet to your service's `.override.jsonnet`:
```
{
  trace_configmap+: {
    data_+:: {
      LogCallsByDefault: true,
    }
  }
}
```

[DT-4029]: https://outreach-io.atlassian.net/browse/DT-4029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ