### PR TITLE
fix: DT-3870 use a new timeout context to shut down tracer

### DIFF
--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -180,9 +180,12 @@ func (t *otelTracer) closeTracer(ctx context.Context) {
 
 	t.tracerProvider.ForceFlush(ctx)
 
-	err := t.tracerProvider.Shutdown(ctx)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+
+	err := t.tracerProvider.Shutdown(ctxTimeout)
 	if err != nil {
-		log.Error(ctx, "Unable to stop otel tracer", events.NewErrorInfo(err))
+		log.Error(ctx, "Unable to stop otel tracer within the context timeout", events.NewErrorInfo(err))
 	}
 }
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This PR tries to fix the issue when service is shut down, otel needs the context but the context has been cancelled. Here it creates a new context with 3 seconds timeout for shutting down the trace provider.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3870]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
