### PR TITLE
fix: make updater.Disabled usable

### DIFF
--- a/pkg/cli/updater/updater.go
+++ b/pkg/cli/updater/updater.go
@@ -41,10 +41,10 @@ import (
 //
 // or you can do it in main() before UseUpdater is called:
 //
-//	updater.Disabled="true"
+//	updater.Disabled = "true"
 //
 // Any value other than "true" is considered false.
-// The type must be string to allow -ldflags "-X ..."
+// The type is string to allow for invoking via `go run -ldflags "-X ..."`.
 var Disabled = "false"
 
 // UseUpdater creates an automatic updater.

--- a/pkg/cli/updater/updater.go
+++ b/pkg/cli/updater/updater.go
@@ -33,10 +33,19 @@ import (
 	"golang.org/x/term"
 )
 
-// Disabled globally disables the automatic updater. This is helpful
-// for when using an external package manager, such as brew.
-// This should usually be done with an ldflag.
-var Disabled bool
+// Disabled globally disables the automatic updater.
+// This is helpful for when using an external package manager, such as brew.
+// This should usually be done with an ldflag:
+//
+//	go run -ldflags "-X github.com/getoutreach/gobox/pkg/cli/updater.Disabled=true" ...
+//
+// or you can do it in main() before UseUpdater is called:
+//
+//	updater.Disabled="true"
+//
+// Any value other than "true" is considered false.
+// The type must be string to allow -ldflags "-X ..."
+var Disabled = "false"
 
 // UseUpdater creates an automatic updater.
 func UseUpdater(ctx context.Context, opts ...Option) (*updater, error) { //nolint:revive // Why: Purposely not exported.
@@ -115,10 +124,12 @@ type updater struct {
 
 // defaultOptions configures the default options for the updater if
 // not already set
+// nolint:funlen // Why: a lot of options to set
 func (u *updater) defaultOptions() error {
-	if Disabled {
+	if Disabled == "true" {
 		u.disabled = true
 		u.disabledReason = "disabled via go linker"
+		return nil
 	}
 
 	if u.log == nil {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Updater package defines `Disabled bool` that should be usable as a global kill switch of updater services. Unfortunately it is useless:
- the suggested usage via ldflags does not work. It fails `github.com/getoutreach/gobox/pkg/cli/updater.Disabled: cannot set with -X: not a var of type string (type:bool)` and [documentation](https://pkg.go.dev/cmd/link) is clear - it must be string if we want to use it this way.
- alternatively if you try `updater.Disabled = true` it does not really disable the initialization which likely fails and logs a warning.

So this PR fixes the behavior. Turns it into string and stops `defaultOptions()` successfully.



<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
