### PR TITLE
fix(aws): prefer using CLI flags over env for okta-aws-cli

### DIFF
--- a/pkg/cli/aws/aws.go
+++ b/pkg/cli/aws/aws.go
@@ -237,7 +237,7 @@ func refreshCredsViaOktaAWSCLI(
 	if acopts.DryRun {
 		copts.Log.Infof("Dry Run: okta-aws-cli %s", strings.Join(args, " "))
 	} else {
-		err := runOktaAwsCLI(ctx, b, args...)
+		err := runOktaAwsCLI(ctx, args...)
 		if err != nil {
 			return errors.Wrap(err, "failed to refresh AWS credentials via okta-aws-cli")
 		}
@@ -258,7 +258,7 @@ func oktaAwsCLICmd(ctx context.Context, args ...string) *exec.Cmd {
 // runOktaAwsCLI is a wrapper for running okta-aws-cli via exec.CommandContext,
 // passing through stdin/stdout/stderr, and setting the appropriate
 // environment variables.
-func runOktaAwsCLI(ctx context.Context, b *box.Config, args ...string) error {
+func runOktaAwsCLI(ctx context.Context, args ...string) error {
 	cmd := oktaAwsCLICmd(ctx, args...)
 	cmd.Stdout = os.Stdout
 	// Prefer using the CLI flags over the environment variables,

--- a/pkg/cli/aws/aws_test.go
+++ b/pkg/cli/aws/aws_test.go
@@ -127,7 +127,16 @@ func Test_refreshCredsViaOktaAWSCLI(t *testing.T) {
 		copts := DefaultCredentialOptions()
 		copts.Log = log
 
-		b := &box.Config{}
+		b := &box.Config{
+			AWS: box.AWSConfig{
+				Okta: box.OktaConfig{
+					FederationAppID: "0oFedExample",
+					OIDCClientID:    "0oExample",
+					OrgDomain:       "example.okta.com",
+					SessionDuration: 1234,
+				},
+			},
+		}
 
 		acopts := &AuthorizeCredentialsOptions{
 			DryRun: true,
@@ -140,6 +149,10 @@ func Test_refreshCredsViaOktaAWSCLI(t *testing.T) {
 		assert.Assert(t, strings.HasPrefix(msg, "Dry Run: okta-aws-cli"))
 		assert.Assert(t, cmp.Contains(msg, "--aws-iam-role "))
 		assert.Assert(t, cmp.Contains(msg, "--write-aws-credentials"))
+		assert.Assert(t, cmp.Contains(msg, "--org-domain example.okta.com"))
+		assert.Assert(t, cmp.Contains(msg, "--oidc-client-id 0oExample"))
+		assert.Assert(t, cmp.Contains(msg, "--aws-acct-fed-app-id 0oFedExample"))
+		assert.Assert(t, cmp.Contains(msg, "--session-duration 1234"))
 	})
 
 	t.Run("interactive role selection", func(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it

`okta-aws-cli` v2 renamed certain environment variables for consistency. Instead of making sure that all of the environment variable permutations are accounted for, avoid using the environment to set those values, and instead use the CLI flags (which did not change between v1 and v2).

## Jira ID

[DT-4091]