### PR TITLE
feat: allow controlling of StartCall info logging from a service runtime

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,7 +59,7 @@ var httpCallLatency = promauto.NewHistogramVec( // nolint:gochecknoglobals // Wh
 		Help:    "The latency of the HTTP request, in seconds",
 		Buckets: prometheus.DefBuckets,
 	},
-	[]string{"app", "call", "statuscode", "statuscategory", "kind"}, // Labels
+	[]string{"target", "call", "statuscode", "statuscategory", "kind"}, // Labels
 )
 
 // ReportHTTPLatency reports the http_request_handled metric for a request.
@@ -90,7 +90,7 @@ var grpcCallLatency = promauto.NewHistogramVec( // nolint:gochecknoglobals // Wh
 		Help:    "The latency of the gRPC request, in seconds",
 		Buckets: prometheus.DefBuckets,
 	},
-	[]string{"app", "call", "statuscode", "statuscategory", "kind"}, // Labels
+	[]string{"target", "call", "statuscode", "statuscategory", "kind"}, // Labels
 )
 
 // ReportGRPCLatency reports the grpc_request_handled metric for a request.
@@ -121,7 +121,7 @@ var outboundCallLatency = promauto.NewHistogramVec( // nolint:gochecknoglobals /
 		Help:    "The latency of the outbound request, in seconds",
 		Buckets: prometheus.DefBuckets,
 	},
-	[]string{"app", "call", "statuscode", "statuscategory", "kind"}, // Labels
+	[]string{"target", "call", "statuscode", "statuscategory", "kind"}, // Labels
 )
 
 // ReportOutboundLatency reports the outbound_call_seconds metric for a request.

--- a/pkg/trace/call.go
+++ b/pkg/trace/call.go
@@ -125,7 +125,19 @@ func SetCustomCallKind(ctx context.Context, ck metrics.CallKind) {
 // GetCallName returns name of the current call
 func GetCallName(ctx context.Context) string {
 	info := callTracker.Info(ctx)
-	return info.Name
+	if info != nil {
+		return info.Name
+	}
+	return ""
+}
+
+// IsInfoLoggingEnabled returns state of info logging
+func IsInfoLoggingEnabled(ctx context.Context) bool {
+	info := callTracker.Info(ctx)
+	if info != nil {
+		return info.Opts.EnableInfoLogging
+	}
+	return false
 }
 
 // EndCall calculates the duration of the call, writes to metrics,

--- a/pkg/trace/call_test.go
+++ b/pkg/trace/call_test.go
@@ -339,11 +339,11 @@ func TestReportLatencyMetrics(t *testing.T) {
 	}, protocmp.Transform()))
 
 	assert.Check(t, cmp.Equal(metric.GetLabel(), []*dto.LabelPair{
-		{Name: proto.String("app"), Value: proto.String("gobox")},
 		{Name: proto.String("call"), Value: proto.String("test")},
 		{Name: proto.String("kind"), Value: proto.String("internal")},
 		{Name: proto.String("statuscategory"), Value: proto.String("CategoryOK")},
 		{Name: proto.String("statuscode"), Value: proto.String("OK")},
+		{Name: proto.String("target"), Value: proto.String("gobox")},
 	}, protocmp.Transform()))
 }
 

--- a/pkg/trace/resolver.go
+++ b/pkg/trace/resolver.go
@@ -1,0 +1,41 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains constants and tools for controlling trace.Start/EndCall logging
+
+package trace
+
+import (
+	"context"
+
+	"github.com/getoutreach/gobox/pkg/log"
+)
+
+type InfoLoggingResolved int32
+
+const (
+	InfoLoggingDefault  InfoLoggingResolved = 0
+	InfoLoggingEnabled  InfoLoggingResolved = 1
+	InfoLoggingDisabled InfoLoggingResolved = 2
+)
+
+type InfoLoggingResolver = func(ctx context.Context, operation string) InfoLoggingResolved
+
+// ResolvedLogging returns signals trace.EndCall whether to enable/disable info logging
+func ResolvedLogging(logging InfoLoggingResolved) log.Marshaler {
+	if logging == InfoLoggingDefault {
+		return nil
+	}
+	if logging == InfoLoggingEnabled {
+		return WithInfoLoggingEnabled()
+	}
+	return WithInfoLoggingDisabled()
+}
+
+func ReevaluateLogging(ctx context.Context, resolver InfoLoggingResolver) {
+	logging := resolver(ctx, GetCallName(ctx))
+	if logging == InfoLoggingDefault {
+		return
+	}
+	callInfo := callTracker.Info(ctx)
+	callInfo.Opts.EnableInfoLogging = logging == InfoLoggingEnabled
+}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Your service can implement custom evaluation function to control emission of trace.StartCall info logs from Go services in real time based on as granular conditions as you wish.

<!-- <<Stencil::Block(jiraPrefix)>> -->


<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
