### PR TITLE
fix: stop dual initiation of trace clients

### DIFF
--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -97,7 +97,7 @@ func (t *otelTracer) initTracer(ctx context.Context, serviceName string) error {
 	// We want to default to initializating and sending traces through the opentelemetry collectors.
 	// But the fallthrough is to send to Honeycomb directly.
 	if t.Otel.CollectorEndpoint != "" {
-		client = t.newOpentelemetryClient(ctx)
+		client = t.newOpentelemetryClient()
 	} else {
 		client = t.newHoneycombClient(ctx)
 	}
@@ -170,7 +170,7 @@ func (t *otelTracer) newHoneycombClient(ctx context.Context) otlptrace.Client {
 // Initializes the otlptracegrpc client to send to the OpenTelemetry collector running in k8s.
 // This is the preferred method for sending traces.
 // The OTEL collector enables us to generate span metrics, should we want those, to dual send, or quickly switch to a different tracing provider.
-func (t *otelTracer) newOpentelemetryClient(ctx context.Context) otlptrace.Client {
+func (t *otelTracer) newOpentelemetryClient() otlptrace.Client {
 	client := otlptracegrpc.NewClient(
 		otlptracegrpc.WithEndpoint(t.Otel.CollectorEndpoint),
 		// There is no need for TLS because we're sending traffic to a kubernetes service

--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -169,7 +169,9 @@ func (t *otelTracer) newHoneycombClient(ctx context.Context) otlptrace.Client {
 
 // Initializes the otlptracegrpc client to send to the OpenTelemetry collector running in k8s.
 // This is the preferred method for sending traces.
-// The OTEL collector enables us to generate span metrics, should we want those, to dual send, or quickly switch to a different tracing provider.
+// The OTEL collector enables us to do the following:
+// 1) generate span metrics, should we want those.
+// 2) dual send traces, or quickly switch to a different tracing provider.
 func (t *otelTracer) newOpentelemetryClient() otlptrace.Client {
 	client := otlptracegrpc.NewClient(
 		otlptracegrpc.WithEndpoint(t.Otel.CollectorEndpoint),


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
If the otel collector endpoint is specified we should _not_ initiation a new client for honeycomb.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-4286]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-4286]: https://outreach-io.atlassian.net/browse/DT-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ