### PR TITLE
feat(olog): add charm-style formatter for logrus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/briandowns/spinner v1.23.0
 	github.com/charmbracelet/glamour v0.7.0
+	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/charmbracelet/log v0.4.0
 	github.com/creack/pty v1.1.21
 	github.com/davecgh/go-spew v1.1.1
@@ -54,7 +55,6 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.8.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/lipgloss v0.10.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
@@ -104,7 +104,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.15.2 // indirect
+	github.com/muesli/termenv v0.15.2
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.48.0 // indirect

--- a/go.work.sum
+++ b/go.work.sum
@@ -335,6 +335,7 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=

--- a/pkg/olog/logrus.go
+++ b/pkg/olog/logrus.go
@@ -8,8 +8,8 @@
 //
 //              Example usage:
 //              ```l := logrus.New()
-//				l.SetFormatter(NewCharmTextFormatter())
-//				l.SetReportCaller(true)```
+//              l.SetFormatter(NewCharmTextFormatter())
+//              l.SetReportCaller(true)```
 //
 //              Example output:
 //              `14:03:38 INFO <qss/qss.go:77> message key=value`

--- a/pkg/olog/logrus.go
+++ b/pkg/olog/logrus.go
@@ -47,6 +47,7 @@ type logrusCharmTextFormat struct {
 	re         *lipgloss.Renderer
 }
 
+// NewCharmTextFormatter creates a new logrus Formatter which uses a charm-style text format
 func NewCharmTextFormatter() logrus.Formatter {
 	return &logrusCharmTextFormat{
 		styles:     charm.DefaultStyles(),
@@ -55,6 +56,7 @@ func NewCharmTextFormatter() logrus.Formatter {
 	}
 }
 
+// Format implements logrus.Formatter using a charm-style text format
 func (l *logrusCharmTextFormat) Format(entry *logrus.Entry) ([]byte, error) {
 	var level charm.Level
 	switch entry.Level {

--- a/pkg/olog/logrus.go
+++ b/pkg/olog/logrus.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -84,8 +85,14 @@ func (l *logrusCharmTextFormat) Format(entry *logrus.Entry) ([]byte, error) {
 		))
 	}
 	entries = append(entries, charm.MessageKey, entry.Message)
-	for k, v := range entry.Data {
-		entries = append(entries, k, v)
+	// stable sort data
+	dataKeys := make([]string, 0, len(entry.Data))
+	for k := range entry.Data {
+		dataKeys = append(dataKeys, k)
+	}
+	sort.Strings(dataKeys)
+	for _, k := range dataKeys {
+		entries = append(entries, k, entry.Data[k])
 	}
 	b := &bytes.Buffer{}
 	l.textFormatter(b, entries...)

--- a/pkg/olog/logrus.go
+++ b/pkg/olog/logrus.go
@@ -1,0 +1,347 @@
+// Copyright 2024 Outreach Corporation. All Rights Reserved.
+
+// Description: Implements a logrus.Formatter interface which follows the format used by the charm logger.
+//              Intended to be used by applications which currently use logrus and want consistently formatted
+//              while using a mix of loggers (logrus and olog). This code was mostly copied from [here](1).
+//
+//              [1]: https://github.com/charmbracelet/log/blob/82b5630d2e68c2cf4c972a926be90149fe0c60b9/text.go "Charm Text Format"
+//
+//              Example usage:
+//              ```l := logrus.New()
+//				l.SetFormatter(NewCharmTextFormatter())
+//				l.SetReportCaller(true)```
+//
+//              Example output:
+//              `14:03:38 INFO <qss/qss.go:77> message key=value`
+
+package olog
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+	charm "github.com/charmbracelet/log"
+	"github.com/muesli/termenv"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	separator       = "="
+	indentSeparator = "  │ "
+)
+
+type logrusCharmTextFormat struct {
+	styles     *charm.Styles
+	timeFormat string
+	re         *lipgloss.Renderer
+}
+
+func NewCharmTextFormatter() logrus.Formatter {
+	return &logrusCharmTextFormat{
+		styles:     charm.DefaultStyles(),
+		timeFormat: "15:04:05",
+		re:         lipgloss.NewRenderer(os.Stdout, termenv.WithColorCache(true)),
+	}
+}
+
+func (l *logrusCharmTextFormat) Format(entry *logrus.Entry) ([]byte, error) {
+	var level charm.Level
+	switch entry.Level {
+	case logrus.FatalLevel, logrus.PanicLevel:
+		level = charm.FatalLevel
+	case logrus.ErrorLevel:
+		level = charm.ErrorLevel
+	case logrus.WarnLevel:
+		level = charm.WarnLevel
+	case logrus.InfoLevel:
+		level = charm.InfoLevel
+	case logrus.DebugLevel, logrus.TraceLevel:
+		level = charm.DebugLevel
+	}
+	entries := []interface{}{
+		charm.TimestampKey, entry.Time,
+		charm.LevelKey, level,
+	}
+	if entry.HasCaller() {
+		entries = append(entries, charm.CallerKey, fmt.Sprintf(
+			"%s/%s:%d",
+			path.Base(filepath.Dir(entry.Caller.File)),
+			path.Base(entry.Caller.File),
+			entry.Caller.Line,
+		))
+	}
+	entries = append(entries, charm.MessageKey, entry.Message)
+	for k, v := range entry.Data {
+		entries = append(entries, k, v)
+	}
+	b := &bytes.Buffer{}
+	l.textFormatter(b, entries...)
+	return b.Bytes(), nil
+}
+
+func (l *logrusCharmTextFormat) writeIndent(w io.Writer, str string, indent string, newline bool, key string) {
+	st := l.styles
+
+	// kindly borrowed from hclog
+	for {
+		nl := strings.IndexByte(str, '\n')
+		if nl == -1 {
+			if str != "" {
+				_, _ = w.Write([]byte(indent))
+				val := escapeStringForOutput(str, false)
+				if valueStyle, ok := st.Values[key]; ok {
+					val = valueStyle.Renderer(l.re).Render(val)
+				} else {
+					val = st.Value.Renderer(l.re).Render(val)
+				}
+				_, _ = w.Write([]byte(val))
+				if newline {
+					_, _ = w.Write([]byte{'\n'})
+				}
+			}
+			return
+		}
+
+		_, _ = w.Write([]byte(indent))
+		val := escapeStringForOutput(str[:nl], false)
+		val = st.Value.Renderer(l.re).Render(val)
+		_, _ = w.Write([]byte(val))
+		_, _ = w.Write([]byte{'\n'})
+		str = str[nl+1:]
+	}
+}
+
+func needsEscaping(str string) bool {
+	for _, b := range str {
+		if !unicode.IsPrint(b) || b == '"' {
+			return true
+		}
+	}
+
+	return false
+}
+
+const (
+	lowerhex = "0123456789abcdef"
+)
+
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		return new(strings.Builder)
+	},
+}
+
+func escapeStringForOutput(str string, escapeQuotes bool) string {
+	// kindly borrowed from hclog
+	if !needsEscaping(str) {
+		return str
+	}
+
+	bb := bufPool.Get().(*strings.Builder)
+	bb.Reset()
+
+	defer bufPool.Put(bb)
+	for _, r := range str {
+		if escapeQuotes && r == '"' {
+			bb.WriteString(`\"`)
+		} else if unicode.IsPrint(r) {
+			bb.WriteRune(r)
+		} else {
+			switch r {
+			case '\a':
+				bb.WriteString(`\a`)
+			case '\b':
+				bb.WriteString(`\b`)
+			case '\f':
+				bb.WriteString(`\f`)
+			case '\n':
+				bb.WriteString(`\n`)
+			case '\r':
+				bb.WriteString(`\r`)
+			case '\t':
+				bb.WriteString(`\t`)
+			case '\v':
+				bb.WriteString(`\v`)
+			default:
+				switch {
+				case r < ' ':
+					bb.WriteString(`\x`)
+					bb.WriteByte(lowerhex[byte(r)>>4])
+					bb.WriteByte(lowerhex[byte(r)&0xF])
+				case !utf8.ValidRune(r):
+					r = 0xFFFD
+					fallthrough
+				case r < 0x10000:
+					bb.WriteString(`\u`)
+					for s := 12; s >= 0; s -= 4 {
+						bb.WriteByte(lowerhex[r>>uint(s)&0xF])
+					}
+				default:
+					bb.WriteString(`\U`)
+					for s := 28; s >= 0; s -= 4 {
+						bb.WriteByte(lowerhex[r>>uint(s)&0xF])
+					}
+				}
+			}
+		}
+	}
+
+	return bb.String()
+}
+
+func needsQuoting(s string) bool {
+	for i := 0; i < len(s); {
+		b := s[i]
+		if b < utf8.RuneSelf {
+			if needsQuotingSet[b] {
+				return true
+			}
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError || unicode.IsSpace(r) || !unicode.IsPrint(r) {
+			return true
+		}
+		i += size
+	}
+	return false
+}
+
+var needsQuotingSet = [utf8.RuneSelf]bool{
+	'"': true,
+	'=': true,
+}
+
+func init() {
+	for i := 0; i < utf8.RuneSelf; i++ {
+		r := rune(i)
+		if unicode.IsSpace(r) || !unicode.IsPrint(r) {
+			needsQuotingSet[i] = true
+		}
+	}
+}
+
+func writeSpace(w io.Writer, first bool) {
+	if !first {
+		w.Write([]byte{' '}) //nolint: errcheck
+	}
+}
+
+func (l *logrusCharmTextFormat) textFormatter(b *bytes.Buffer, keyvals ...interface{}) {
+	st := l.styles
+	lenKeyvals := len(keyvals)
+
+	for i := 0; i < lenKeyvals; i += 2 {
+		firstKey := i == 0
+		moreKeys := i < lenKeyvals-2
+
+		switch keyvals[i] {
+		case charm.TimestampKey:
+			if t, ok := keyvals[i+1].(time.Time); ok {
+				ts := t.Format(l.timeFormat)
+				ts = st.Timestamp.Renderer(l.re).Render(ts)
+				writeSpace(b, firstKey)
+				b.WriteString(ts)
+			}
+		case charm.LevelKey:
+			if level, ok := keyvals[i+1].(charm.Level); ok {
+				var lvl string
+				lvlStyle, ok := st.Levels[level]
+				if !ok {
+					continue
+				}
+
+				lvl = lvlStyle.Renderer(l.re).String()
+				if lvl != "" {
+					writeSpace(b, firstKey)
+					b.WriteString(lvl)
+				}
+			}
+		case charm.CallerKey:
+			if caller, ok := keyvals[i+1].(string); ok {
+				caller = fmt.Sprintf("<%s>", caller)
+				caller = st.Caller.Renderer(l.re).Render(caller)
+				writeSpace(b, firstKey)
+				b.WriteString(caller)
+			}
+		case charm.PrefixKey:
+			if prefix, ok := keyvals[i+1].(string); ok {
+				prefix = st.Prefix.Renderer(l.re).Render(prefix + ":")
+				writeSpace(b, firstKey)
+				b.WriteString(prefix)
+			}
+		case charm.MessageKey:
+			if msg := keyvals[i+1]; msg != nil {
+				m := fmt.Sprint(msg)
+				m = st.Message.Renderer(l.re).Render(m)
+				writeSpace(b, firstKey)
+				b.WriteString(m)
+			}
+		default:
+			sep := separator
+			indentSep := indentSeparator
+			sep = st.Separator.Renderer(l.re).Render(sep)
+			indentSep = st.Separator.Renderer(l.re).Render(indentSep)
+			key := fmt.Sprint(keyvals[i])
+			val := fmt.Sprintf("%+v", keyvals[i+1])
+			raw := val == ""
+			if raw {
+				val = `""`
+			}
+			if key == "" {
+				continue
+			}
+			actualKey := key
+			valueStyle := st.Value
+			if vs, ok := st.Values[actualKey]; ok {
+				valueStyle = vs
+			}
+			if keyStyle, ok := st.Keys[key]; ok {
+				key = keyStyle.Renderer(l.re).Render(key)
+			} else {
+				key = st.Key.Renderer(l.re).Render(key)
+			}
+
+			// Values may contain multiple lines, and that format
+			// is preserved, with each line prefixed with a "  | "
+			// to show it's part of a collection of lines.
+			//
+			// Values may also need quoting, if not all the runes
+			// in the value string are "normal", like if they
+			// contain ANSI escape sequences.
+			if strings.Contains(val, "\n") {
+				b.WriteString("\n  ")
+				b.WriteString(key)
+				b.WriteString(sep + "\n")
+				l.writeIndent(b, val, indentSep, moreKeys, actualKey)
+			} else if !raw && needsQuoting(val) {
+				writeSpace(b, firstKey)
+				b.WriteString(key)
+				b.WriteString(sep)
+				b.WriteString(valueStyle.Renderer(l.re).Render(fmt.Sprintf(`"%s"`,
+					escapeStringForOutput(val, true))))
+			} else {
+				val = valueStyle.Renderer(l.re).Render(val)
+				writeSpace(b, firstKey)
+				b.WriteString(key)
+				b.WriteString(sep)
+				b.WriteString(val)
+			}
+		}
+	}
+
+	// Add a newline to the end of the log message.
+	b.WriteByte('\n')
+}

--- a/pkg/olog/logrus.go
+++ b/pkg/olog/logrus.go
@@ -5,14 +5,6 @@
 //              while using a mix of loggers (logrus and olog). This code was mostly copied from [here](1).
 //
 //              [1]: https://github.com/charmbracelet/log/blob/82b5630d2e68c2cf4c972a926be90149fe0c60b9/text.go "Charm Text Format"
-//
-//              Example usage:
-//              ```l := logrus.New()
-//              l.SetFormatter(NewCharmTextFormatter())
-//              l.SetReportCaller(true)```
-//
-//              Example output:
-//              `14:03:38 INFO <qss/qss.go:77> message key=value`
 
 package olog
 
@@ -48,8 +40,16 @@ type logrusCharmTextFormat struct {
 	re         *lipgloss.Renderer
 }
 
-// NewCharmTextFormatter creates a new logrus Formatter which uses a charm-style text format
-func NewCharmTextFormatter() logrus.Formatter {
+// NewLogrusTextFormatter creates a new logrus Formatter which uses a charm-style text format.
+//
+//	Example usage:
+//	```l := logrus.New()
+//	l.SetFormatter(olog.NewLogrusTextFormatter())
+//	l.SetReportCaller(true)```
+//
+//	Example output:
+//	`14:03:38 INFO <qss/qss.go:77> message key=value`
+func NewLogrusTextFormatter() logrus.Formatter {
 	return &logrusCharmTextFormat{
 		styles:     charm.DefaultStyles(),
 		timeFormat: "15:04:05",
@@ -74,7 +74,7 @@ func logrusToCharmLevel(logrusLevel logrus.Level) charm.Level {
 	return level
 }
 
-// Format implements logrus.Formatter using a charm-style text format
+// Format implements logrus.Formatter using a charm-style text format.
 func (l *logrusCharmTextFormat) Format(entry *logrus.Entry) ([]byte, error) {
 	level := logrusToCharmLevel(entry.Level)
 	entries := []interface{}{

--- a/pkg/olog/logrus_test.go
+++ b/pkg/olog/logrus_test.go
@@ -16,6 +16,7 @@ func TestTextLogger(t *testing.T) {
 	logger := logrus.New()
 	logger.SetFormatter(NewCharmTextFormatter())
 	logger.SetOutput(&buffer)
+	logger.SetLevel(logrus.DebugLevel)
 	cases := []struct {
 		name     string
 		expected string
@@ -31,8 +32,8 @@ func TestTextLogger(t *testing.T) {
 			level:    logrus.InfoLevel,
 		},
 		{
-			name:     "ignored message",
-			expected: "",
+			name:     "debug message",
+			expected: "DEBU this is a debug message\n",
 			msg:      "this is a debug message",
 			fields:   nil,
 			level:    logrus.DebugLevel,

--- a/pkg/olog/logrus_test.go
+++ b/pkg/olog/logrus_test.go
@@ -1,0 +1,141 @@
+package olog
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+	"gotest.tools/v3/assert"
+)
+
+func TestTextLogger(t *testing.T) {
+	buffer := bytes.Buffer{}
+	logger := logrus.New()
+	logger.SetFormatter(NewCharmTextFormatter())
+	logger.SetOutput(&buffer)
+	cases := []struct {
+		name     string
+		expected string
+		msg      string
+		fields   logrus.Fields
+		level    logrus.Level
+	}{
+		{
+			name:     "simple message",
+			expected: "INFO info\n",
+			msg:      "info",
+			fields:   nil,
+			level:    logrus.InfoLevel,
+		},
+		{
+			name:     "ignored message",
+			expected: "",
+			msg:      "this is a debug message",
+			fields:   nil,
+			level:    logrus.DebugLevel,
+		},
+		{
+			name:     "message with keyvals",
+			expected: "INFO info key1=val1 key2=val2\n",
+			msg:      "info",
+			fields: logrus.Fields{
+				"key1": "val1",
+				"key2": "val2",
+			},
+			level: logrus.InfoLevel,
+		},
+		{
+			name:     "error message with keyvals",
+			expected: "ERRO info key1=val1 key2=val2\n",
+			msg:      "info",
+			fields: logrus.Fields{
+				"key1": "val1",
+				"key2": "val2",
+			},
+			level: logrus.ErrorLevel,
+		},
+		{
+			name:     "error message with multiline",
+			expected: "ERRO info\n  key1=\n  │ val1\n  │ val2\n",
+			msg:      "info",
+			fields: logrus.Fields{
+				"key1": "val1\nval2",
+			},
+			level: logrus.ErrorLevel,
+		},
+		{
+			name:     "error field",
+			expected: "ERRO info key1=\"error value\"\n",
+			msg:      "info",
+			fields:   logrus.Fields{"key1": errors.New("error value")},
+			level:    logrus.ErrorLevel,
+		},
+		{
+			name:     "struct field",
+			expected: "ERRO info key1={foo:bar}\n",
+			msg:      "info",
+			fields:   logrus.Fields{"key1": struct{ foo string }{foo: "bar"}},
+			level:    logrus.ErrorLevel,
+		},
+		{
+			name:     "struct field quoted",
+			expected: "ERRO info key1=\"{foo:bar baz}\"\n",
+			msg:      "info",
+			fields:   logrus.Fields{"key1": struct{ foo string }{foo: "bar baz"}},
+			level:    logrus.ErrorLevel,
+		},
+		{
+			name:     "slice of strings",
+			expected: "ERRO info key1=\"[foo bar]\"\n",
+			msg:      "info",
+			fields:   logrus.Fields{"key1": []string{"foo", "bar"}},
+			level:    logrus.ErrorLevel,
+		},
+		{
+			name:     "slice of structs",
+			expected: "ERRO info key1=\"[{foo:bar} {foo:baz}]\"\n",
+			msg:      "info",
+			fields:   logrus.Fields{"key1": []struct{ foo string }{{foo: "bar"}, {foo: "baz"}}},
+			level:    logrus.ErrorLevel,
+		},
+		{
+			name:     "slice of errors",
+			expected: "ERRO info key1=\"[error value1 error value2]\"\n",
+			msg:      "info",
+			fields:   logrus.Fields{"key1": []error{errors.New("error value1"), errors.New("error value2")}},
+			level:    logrus.ErrorLevel,
+		},
+		{
+			name:     "map of strings",
+			expected: "ERRO info key1=\"map[baz:qux foo:bar]\"\n",
+			msg:      "info",
+			fields:   logrus.Fields{"key1": map[string]string{"foo": "bar", "baz": "qux"}},
+			level:    logrus.ErrorLevel,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			buffer.Reset()
+			var l logrus.FieldLogger
+			l = logger
+			if c.fields != nil {
+				l = l.WithFields(c.fields)
+			}
+			switch c.level { // nolint: exhaustive // Why: only testing certain levels
+			case logrus.DebugLevel:
+				l.Debug(c.msg)
+			case logrus.InfoLevel:
+				l.Info(c.msg)
+			case logrus.WarnLevel:
+				l.Warn(c.msg)
+			case logrus.ErrorLevel:
+				l.Error(c.msg)
+			}
+			bufS := buffer.String()
+			assert.Assert(t, strings.HasSuffix(bufS, c.expected), cmp.Diff(bufS, c.expected))
+		})
+	}
+}

--- a/pkg/olog/logrus_test.go
+++ b/pkg/olog/logrus_test.go
@@ -14,7 +14,7 @@ import (
 func TestTextLogger(t *testing.T) {
 	buffer := bytes.Buffer{}
 	logger := logrus.New()
-	logger.SetFormatter(NewCharmTextFormatter())
+	logger.SetFormatter(NewLogrusTextFormatter())
 	logger.SetOutput(&buffer)
 	logger.SetLevel(logrus.DebugLevel)
 	cases := []struct {


### PR DESCRIPTION
## What this PR does / why we need it
Add a charm-style formatter for logrus to have consistent logging formats.

### Background

`log/slog` has been widely accepted by the community as the new standard for logging in Go. This olog package is our implementation of it which uses the charm logger. However, we are currently using logrus in many places for CLI applications. In order to have consistency in our log formats, I decided to create a custom logrus formatter which matches the text format of the charm logger.


### Notes

Most of this is copied from the [charm text formatter](https://github.com/charmbracelet/log/blob/82b5630d2e68c2cf4c972a926be90149fe0c60b9/text.go), but it's been slightly tweaked. The `Format` method is what fulfills the logrus interface. It creates the right request shape and byte buffer to call into `textFormatter`. The bytes are then extracted and returned to logrus.

While this mimics the formatting of olog, it still can't handle switching to JSON when stdout is not attached to a TTY. I don't intend to nor do I think we should handle that.

### Example

![image](https://github.com/getoutreach/gobox/assets/4716191/9fc09764-ce57-416a-a1f7-30de41631da5)