### PR TITLE
fix: log trace IDs in StartCall

### DIFF
--- a/pkg/trace/call.go
+++ b/pkg/trace/call.go
@@ -52,7 +52,7 @@ var logCallsByDefault = false
 //
 // StartCalls can be nested.
 func StartCall(ctx context.Context, cType string, args ...log.Marshaler) context.Context {
-	log.Debug(ctx, fmt.Sprintf("calling: %s", cType), args...)
+	log.Debug(ctx, fmt.Sprintf("calling: %s", cType), append(args, IDs(ctx))...)
 
 	// Specify the default behavior first in line.  It might be overridden
 	// by later args and that's OK.


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

We are already logging trace IDs in EndCall, but we don't do it in StartCall.
Thus we currently cannot distinguish correctly between the requests.

![Screenshot 2024-06-06 at 13 43 43](https://github.com/getoutreach/gobox/assets/27106/de4cbe49-afbe-42d2-a047-e84283556013)

With this PR the `trace_id` is present correctly:

![trace_ids](https://github.com/getoutreach/gobox/assets/27106/8a061b0b-ab1e-4d6e-a6ba-d32db1f170ef)

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
