### PR TITLE
feat: add capability to have a status code for request being cancelled

### DIFF
--- a/pkg/statuscodes/statuscode_string.go
+++ b/pkg/statuscodes/statuscode_string.go
@@ -16,6 +16,7 @@ func _() {
 	_ = x[Conflict-704]
 	_ = x[RateLimited-705]
 	_ = x[ClientConnectionSevered-706]
+	_ = x[Cancelled-707]
 	_ = x[InternalServerError-800]
 	_ = x[NotImplemented-801]
 	_ = x[Unavailable-802]
@@ -25,12 +26,12 @@ func _() {
 
 const (
 	_StatusCode_name_0 = "OK"
-	_StatusCode_name_1 = "BadRequestUnauthorizedForbiddenNotFoundConflictRateLimitedClientConnectionSevered"
+	_StatusCode_name_1 = "BadRequestUnauthorizedForbiddenNotFoundConflictRateLimitedClientConnectionSeveredCancelled"
 	_StatusCode_name_2 = "InternalServerErrorNotImplementedUnavailableUnknownErrorDeadlineExceeded"
 )
 
 var (
-	_StatusCode_index_1 = [...]uint8{0, 10, 22, 31, 39, 47, 58, 81}
+	_StatusCode_index_1 = [...]uint8{0, 10, 22, 31, 39, 47, 58, 81, 90}
 	_StatusCode_index_2 = [...]uint8{0, 19, 33, 44, 56, 72}
 )
 
@@ -38,7 +39,7 @@ func (i StatusCode) String() string {
 	switch {
 	case i == 600:
 		return _StatusCode_name_0
-	case 700 <= i && i <= 706:
+	case 700 <= i && i <= 707:
 		i -= 700
 		return _StatusCode_name_1[_StatusCode_index_1[i]:_StatusCode_index_1[i+1]]
 	case 800 <= i && i <= 804:

--- a/pkg/statuscodes/statuscodes.go
+++ b/pkg/statuscodes/statuscodes.go
@@ -51,6 +51,8 @@ const (
 	// This can occur when a service is using a client to connect to a downstream service. When making the request
 	// it is not sent because the connection has been severed.
 	ClientConnectionSevered StatusCode = 706
+	// Cancelled should be used when the caller has cancelled the request.
+	Cancelled StatusCode = 707
 
 	// The 800-swath is for Server-caused error responses
 	// InternalServerError is for when something otherwise uncategorizable has blown up inside the service logic.
@@ -131,6 +133,8 @@ func FromString(s string) (StatusCode, bool) {
 		return RateLimited, true
 	case ClientConnectionSevered.String():
 		return ClientConnectionSevered, true
+	case Cancelled.String():
+		return Cancelled, true
 	case InternalServerError.String():
 		return InternalServerError, true
 	case NotImplemented.String():

--- a/pkg/statuscodes/statuscodes_test.go
+++ b/pkg/statuscodes/statuscodes_test.go
@@ -12,6 +12,7 @@ func TestStatusCodeUnmarshalText(t *testing.T) {
 		Conflict,
 		RateLimited,
 		ClientConnectionSevered,
+		Cancelled,
 		InternalServerError,
 		NotImplemented,
 		Unavailable,


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This happens when a user/caller cancels the request before being finished. This will improve our metrics, because such cases are reported as InternalServerError currently. 
<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[RMS-4688]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[RMS-4688]: https://outreach-io.atlassian.net/browse/RMS-4688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ