### PR TITLE
fix(olog): add lock to SetOutput

### DIFF
--- a/pkg/olog/olog.go
+++ b/pkg/olog/olog.go
@@ -16,8 +16,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sync"
 
 	"github.com/getoutreach/gobox/pkg/callerinfo"
+)
+
+var (
+	outputLock = new(sync.RWMutex)
 )
 
 // New creates a new slog instance that can be used for logging. The
@@ -118,6 +123,8 @@ func NewWithHandler(h slog.Handler) *slog.Logger {
 
 // SetOutput sets the global logger output to desired writer.
 func SetOutput(w io.Writer) {
+	outputLock.Lock()
+	defer outputLock.Unlock()
 	defaultOut = w
 }
 

--- a/pkg/olog/olog.go
+++ b/pkg/olog/olog.go
@@ -122,6 +122,7 @@ func NewWithHandler(h slog.Handler) *slog.Logger {
 }
 
 // SetOutput sets the global logger output to desired writer.
+// The function uses a mutex to ensure that setting the output writer is thread-safe.
 func SetOutput(w io.Writer) {
 	outputLock.Lock()
 	defer outputLock.Unlock()


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Make the SetOutput function thread safe.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
