### PR TITLE
feat(trace): propagate WithPublicEndpointFn to otel NewHandler

### DIFF
--- a/pkg/trace/roundtripper.go
+++ b/pkg/trace/roundtripper.go
@@ -35,6 +35,11 @@ func NewTransport(old http.RoundTripper) http.RoundTripper {
 // NewHandler creates a new handlers which reads propagated headers
 // from the current trace context.
 //
+// Supported options are:
+//   - WithPublicEndpointFn conditionally configure the Handler to link the span with an incoming span context
+//     instead of child association. Useful for public facing endpoints that don't need to attach to externally
+//     defined traces
+//
 // Usage:
 //
 //		  trace.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) *roundtripperState {
@@ -42,10 +47,10 @@ func NewTransport(old http.RoundTripper) http.RoundTripper {
 //			defer trace.End(r.Context())
 //			... do actual request handling ...
 //	   }), "my endpoint")
-func NewHandler(handler http.Handler, operation string) http.Handler {
+func NewHandler(handler http.Handler, operation string, opts ...HandlerOption) http.Handler {
 	if defaultTracer == nil {
 		return handler
 	}
 
-	return defaultTracer.newHandler(handler, operation)
+	return defaultTracer.newHandler(handler, operation, opts...)
 }

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -46,7 +46,7 @@ type tracer interface {
 
 	newTransport(http.RoundTripper) http.RoundTripper
 
-	newHandler(handler http.Handler, operation string) http.Handler
+	newHandler(handler http.Handler, operation string, opts ...HandlerOption) http.Handler
 
 	toHeaders(ctx context.Context) map[string][]string
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

API Proxy uses NewHandler tracer and it currently "attaches" to trace contexts defined by external callers which may result in useless massive traces saved in our Honeycomb. [Example](https://ui.honeycomb.io/outreach-a0/datasets/outreach/result/FK9qSb6NoWh/trace/hkZSeQZ1mUu?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&fields%5B%5D=c_http.url&span=53cc10310e79186b)

Instead the service shall attach to "internal" callers such as DSNG Sync and Trigger services but reset parent trace for requests initiated by "external" callers. And for that it is necessary to wire [WithPublicEndpointFn](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp#WithPublicEndpointFn) option to initialize `NewHandler` with.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[ADS-577]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

From API POV the change is backwards compatible.

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[ADS-577]: https://outreach-io.atlassian.net/browse/ADS-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ