### PR TITLE
feat(aws): add debug flags

### DIFF
--- a/pkg/cli/aws/aws.go
+++ b/pkg/cli/aws/aws.go
@@ -100,6 +100,13 @@ type AuthorizeCredentialsOptions struct {
 	// If Output is not empty, print the specified format to STDOUT
 	// instead of writing to the AWS credentials file.
 	Output CredentialsOutput
+
+	// Debug is whether to enable debug logging.
+	Debug bool
+
+	// DebugAPICalls is whether to specifically enable debug logging
+	// for API calls. This is not dependent on the Debug flag.
+	DebugAPICalls bool
 }
 
 // assumedToRole takes an assumed-role arn and converts it to the
@@ -249,6 +256,14 @@ func refreshCredsViaOktaAWSCLI(
 		args = append(args, "--format", string(credentialProviderFormat(isCLIVersion1)))
 	} else {
 		args = append(args, "--write-aws-credentials")
+	}
+
+	if acopts.Debug {
+		args = append(args, "--debug")
+	}
+
+	if acopts.DebugAPICalls {
+		args = append(args, "--debug-api-calls")
 	}
 
 	if acopts.DryRun {

--- a/pkg/cli/aws/aws_test.go
+++ b/pkg/cli/aws/aws_test.go
@@ -232,6 +232,49 @@ func Test_refreshCredsViaOktaAWSCLI(t *testing.T) {
 		assert.Assert(t, cmp.Contains(msg, "--format process-credentials"))
 		assert.Assert(t, cmp.Contains(msg, "--aws-iam-idp arn:aws:iam::123456789012:saml-provider/okta"))
 	})
+
+	t.Run("debug", func(t *testing.T) {
+		log, hook := logtest.NewNullLogger()
+		copts := DefaultCredentialOptions()
+		copts.Role = ""
+		copts.Log = log
+
+		b := &box.Config{}
+
+		acopts := &AuthorizeCredentialsOptions{
+			Debug:  true,
+			DryRun: true,
+		}
+
+		err := refreshCredsViaOktaAWSCLI(context.Background(), copts, acopts, b, "")
+		assert.NilError(t, err)
+		assert.Equal(t, len(hook.Entries), 2)
+		msg := hook.LastEntry().Message
+		assert.Assert(t, strings.HasPrefix(msg, "Dry Run: okta-aws-cli"))
+		assert.Assert(t, strings.Contains(msg, "--debug"))
+		assert.Assert(t, !strings.Contains(msg, "--debug-api-calls"))
+	})
+
+	t.Run("debug API calls", func(t *testing.T) {
+		log, hook := logtest.NewNullLogger()
+		copts := DefaultCredentialOptions()
+		copts.Role = ""
+		copts.Log = log
+
+		b := &box.Config{}
+
+		acopts := &AuthorizeCredentialsOptions{
+			DebugAPICalls: true,
+			DryRun:        true,
+		}
+
+		err := refreshCredsViaOktaAWSCLI(context.Background(), copts, acopts, b, "")
+		assert.NilError(t, err)
+		assert.Equal(t, len(hook.Entries), 2)
+		msg := hook.LastEntry().Message
+		assert.Assert(t, strings.HasPrefix(msg, "Dry Run: okta-aws-cli"))
+		assert.Assert(t, strings.Contains(msg, "--debug-api-calls"))
+	})
 }
 
 func Test_oktaAwsCliVersionOutputMatchesV1(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it

Adding support to set `--debug` and `--debug-api-calls` may be helpful when debugging strange issues with `okta-aws-cli`.