### PR TITLE
feat!(rm-cause): causes are harmful

### DIFF
--- a/pkg/events/error.go
+++ b/pkg/events/error.go
@@ -7,6 +7,7 @@ package events
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
 
@@ -37,6 +38,7 @@ func (e *ErrorInfo) MarshalLog(addField func(key string, value interface{})) {
 	if len(e.Stack) > 0 {
 		addField("error.stack", strings.Join(e.Stack, "\n\t"))
 	}
+
 	if e.Cause != nil {
 		addField("error.cause", e.Cause)
 	}
@@ -144,15 +146,6 @@ func NewErrorInfo(err error) *ErrorInfo {
 		Stack:    errStack(err),
 		Custom:   custom,
 	}
-	// obtain nested error, collapsing upward if possible.
-	if cause := nestInfo(errors.Unwrap(err)); cause != nil {
-		if info.pureStack() && cause.pureMessage() {
-			info.Message = cause.Message
-			info.Cause = cause.Cause
-		} else {
-			info.Cause = cause
-		}
-	}
 	return &info
 }
 
@@ -167,15 +160,6 @@ func nestInfo(err error) *nestedErrorInfo {
 		Message:  errMessage(err),
 		Stack:    errStack(err),
 		Custom:   custom,
-	}
-	// obtain nested error, collapsing upward if possible.
-	if cause := nestInfo(errors.Unwrap(err)); cause != nil {
-		if info.pureStack() && cause.pureMessage() {
-			info.Message = cause.Message
-			info.Cause = cause.Cause
-		} else {
-			info.Cause = cause
-		}
 	}
 	return &info
 }


### PR DESCRIPTION
This code is demented. It produces messages like the folliowing
(irrelvant fields redacted):

```json
{
	"content": {
		"attributes": {
			"error": {
				"kind": "error",
				"cause": {
					"kind": "cause",
					"cause": {
						"kind": "cause",
						"cause": {
							"kind": "cause",
							"message": "10.96.232.125:5432 (app2a-callstatemanager-xpmuvqngpcd.cluster-ro-cntwmzilna0e.us-east-1.rds.amazonaws.com): failed to write startup message: context canceled"
						},
						"message": "failed to connect to `user=readwrite database=callstatemanager`"
					},
					"message": "failed to connect to `user=readwrite database=callstatemanager`: 10.96.232.125:5432 (app2a-callstatemanager-xpmuvqngpcd.cluster-ro-cntwmzilna0e.us-east-1.rds.amazonaws.com): failed to write startup message: context canceled getting connection to host app2a-callstatemanager-xpmuvqngpcd.cluster-ro-cntwmzilna0e.us-east-1.rds.amazonaws.com:5432 for org a5fc3e3c-b376-4327-9d80-3e29fe62e6e5"
				},
				"error": "failed to connect to `user=readwrite database=callstatemanager`: 10.96.232.125:5432 (app2a-callstatemanager-xpmuvqngpcd.cluster-ro-cntwmzilna0e.us-east-1.rds.amazonaws.com): failed to write startup message: context canceled getting connection to host app2a-callstatemanager-xpmuvqngpcd.cluster-ro-cntwmzilna0e.us-east-1.rds.amazonaws.com:5432 for org a5fc3e3c-b376-4327-9d80-3e29fe62e6e5",
				"message": ""
			},
		}
	}
}
```

In order to query this, you end up writing statements like
`error.cause.cause.cause.cause.message`

There's no point in that. All of our tools also support "in" queries,
so you can just check `if "context cancelled" in error.error`
(error.error) is also semantically problematic, buit whatvs.

All this does is inflate our log volume and increase meaninglessly the
number of columns in honeycomb queries.

Remove it and profit.

NB: this is a scorched earch approach. Anyone updating would be
immediately su bject to this new behavior, and it might break alerting
if someone was specifically looking for the 5th cause or something goofy
like that.

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
