### PR TITLE
feat(box): add support for engdocs.URL

### DIFF
--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -173,6 +173,12 @@ type SnapshotConfig struct {
 	WriteAWSRole string `yaml:"writeAWSRole"`
 }
 
+// Engdocs is the configuration for engdocs.
+type Engdocs struct {
+	// URL is the base URL to the engdocs instance.
+	URL string `yaml:"URL"`
+}
+
 // Config is the basis of a box configuration
 type Config struct {
 	// RefreshInterval is the interval to use when refreshing a box configuration
@@ -195,6 +201,9 @@ type Config struct {
 
 	// Docker is the configuration for pull/push registries
 	Docker Docker `yaml:"docker"`
+
+	// Engdocs is the configuration for engdocs
+	Engdocs Engdocs `yaml:"engdocs"`
 }
 
 // Storage is a wrapper type used for storing the box configuration


### PR DESCRIPTION
## What this PR does / why we need it

Will allow Stencil and its modules to use the box value, once it's updated with the version this is released with.

## Jira ID

[DT-4745]

[DT-4745]: https://outreach-io.atlassian.net/browse/DT-4745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ