### PR TITLE
fix(cli/updater): typo in ResolveExecutable name

### DIFF
--- a/pkg/cli/updater/updater.go
+++ b/pkg/cli/updater/updater.go
@@ -152,7 +152,7 @@ func (u *updater) defaultOptions() error {
 
 	if u.executablePath == "" {
 		var err error
-		u.executablePath, err = exec.ResolveExecuable(os.Args[0])
+		u.executablePath, err = exec.ResolveExecutable(os.Args[0])
 		if err != nil {
 			u.hookSkipUpdateIntoCLI()
 			return err

--- a/pkg/cli/updater/urfave_cli.go
+++ b/pkg/cli/updater/urfave_cli.go
@@ -89,7 +89,7 @@ func (u *updater) hookIntoCLI() {
 			return cli.Exit("", 0)
 		}
 
-		binPath, err := goboxexec.ResolveExecuable(os.Args[0])
+		binPath, err := goboxexec.ResolveExecutable(os.Args[0])
 		if err != nil {
 			u.log.WithError(err).Warn("Failed to find binary location, please re-run your command manually")
 			return cli.Exit("", 0)

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -27,9 +27,9 @@ func ResolveExecutable(path string) (string, error) {
 	return filepath.Abs(path)
 }
 
-// ResolveExecuable is a wrapper for ResolveExecutable. This is the
-// original function which was misspelled. At some point in the future,
-// this will be deprecated and then removed.
+// ResolveExecuable is a wrapper for ResolveExecutable.
+//
+// Deprecated: use ResolveExecutable.
 func ResolveExecuable(path string) (string, error) {
 	return ResolveExecutable(path)
 }

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -12,7 +12,7 @@ import (
 
 // ResolveExecutable find the absolute path to a given binary.
 // This is meant to be used with os.Args[0]
-func ResolveExecuable(path string) (string, error) {
+func ResolveExecutable(path string) (string, error) {
 	if filepath.IsAbs(path) {
 		return filepath.Clean(path), nil
 	}
@@ -25,4 +25,11 @@ func ResolveExecuable(path string) (string, error) {
 
 	// otherwise we should just return the absolute path (resolve it)
 	return filepath.Abs(path)
+}
+
+// ResolveExecuable is a wrapper for ResolveExecutable. This is the
+// original function which was misspelled. At some point in the future,
+// this will be deprecated and then removed.
+func ResolveExecuable(path string) (string, error) {
+	return ResolveExecutable(path)
 }

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -15,7 +15,7 @@ func getCwd() string {
 	return dir
 }
 
-func TestResolveExecuable(t *testing.T) {
+func TestResolveExecutable(t *testing.T) {
 	type args struct {
 		path string
 	}
@@ -63,13 +63,13 @@ func TestResolveExecuable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ResolveExecuable(tt.args.path)
+			got, err := ResolveExecutable(tt.args.path)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ResolveExecuable() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ResolveExecutable() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("ResolveExecuable() = %v, want %v", got, tt.want)
+				t.Errorf("ResolveExecutable() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.

Eventually the deprecated misspelled function will be removed.

## Jira ID

[DT-4756]

[DT-4756]: https://outreach-io.atlassian.net/browse/DT-4756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ