### PR TITLE
fix(cli): regression related to cleanup/exit functions

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -120,7 +120,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, a *cliV2.App, conf *Con
 	}
 
 	cFuncs, exitCode, osExiter := setupRun(ctx, cancel, conf, logger, a.Name)
-	defer cFuncs.All()
+	defer cFuncs.All()()
 
 	if _, err := updater.UseUpdater(ctx, updater.WithApp(a), updater.WithLogger(logger)); err != nil {
 		logger.WithError(err).Warn("Failed to setup automatic updater")
@@ -166,7 +166,7 @@ func RunV3(ctx context.Context, cancel context.CancelFunc, c *cliV3.Command, con
 	}
 
 	cFuncs, exitCode, osExiter := setupRun(ctx, cancel, conf, logger, c.Name)
-	defer cFuncs.All()
+	defer cFuncs.All()()
 
 	if _, err := updater.UseUpdater(ctx, updater.WithAppV3(c), updater.WithLogger(logger)); err != nil {
 		logger.WithError(err).Warn("Failed to setup automatic updater")


### PR DESCRIPTION

## What this PR does / why we need it
We detected the issue since a consuming tool (`devenv`) stopped returning `1` on error.
`defer` does nothing with the returned `func()`, dev has to call that further.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
