### PR TITLE
fix(otel): return input if nooping

### DIFF
--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -297,7 +297,7 @@ func Error(ctx context.Context, err error, opts ...RecordErrorOption) error {
 	// if the error is nil we no-op
 	// if tracing is not enabled, no-op
 	if err == nil || defaultTracer == nil {
-		return nil
+		return err
 	}
 
 	// conform to outreach specific expectations:


### PR DESCRIPTION
A test in smartstore failed when I tried to use this because
the tracer was not enabled. This is unlikely to lead to production
issues, since our tracer is almost always enabled, but it would lead to
test failures elsewhere too.

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
