### PR TITLE
fix(logger): add With method to logger

### DIFF
--- a/pkg/log/with.go
+++ b/pkg/log/with.go
@@ -45,3 +45,8 @@ func (l logger) Error(ctx context.Context, message string, m ...Marshaler) {
 func (l logger) Fatal(ctx context.Context, message string, m ...Marshaler) {
 	Fatal(ctx, message, append(m, l.m...)...)
 }
+
+// With returns a new logger with additional marshalers appended.
+func (l logger) With(m ...Marshaler) logger {
+	return logger{append(l.m, m...)}
+}

--- a/pkg/log/with_test.go
+++ b/pkg/log/with_test.go
@@ -70,3 +70,30 @@ func (withSuite) TestWith(t *testing.T) {
 		t.Fatal("unexpected log entries", diff)
 	}
 }
+
+func (withSuite) TestWithChaining(t *testing.T) {
+	logs := logtest.NewLogRecorder(t)
+	defer logs.Close()
+
+	logger := log.With(log.F{"first": "value1"}).With(log.F{"second": "value2"})
+	ctx := context.Background()
+
+	logger.Info(ctx, "Chained message", log.F{"third": "value3"})
+
+	expected := []log.F{
+		{
+			"@timestamp":  differs.RFC3339NanoTime(),
+			"app.version": "testing",
+			"level":       "INFO",
+			"message":     "Chained message",
+			"first":       "value1",
+			"second":      "value2",
+			"third":       "value3",
+			"module":      "github.com/getoutreach/gobox",
+		},
+	}
+
+	if diff := cmp.Diff(expected, logs.Entries(), differs.Custom()); diff != "" {
+		t.Fatal("unexpected log entries", diff)
+	}
+}


### PR DESCRIPTION
We can create loggers with logging context, but we can not append to that logging context. Add a `With` method to loggers to allow creating child loggers with both the parent logging context and additional context.

See: https://github.com/getoutreach/database-provisioning-operator/pull/352#discussion_r2529042776