### PR TITLE
feat(cli): add Confirm, MultiSelect, and a generic PickOne prompt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/sahilm/fuzzy v0.1.3 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
@@ -210,6 +212,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.3 h1:juByESSS32nVD81vr6tHmKmA/8zde7gE+x5CLxrzXPU=
+github.com/sahilm/fuzzy v0.1.3/go.mod h1:au6//VbVSqu6DFrkL2CfjlJ5iURpNCPeE+1GwY3XsT8=
 github.com/schollz/progressbar/v3 v3.19.0 h1:Ea18xuIRQXLAUidVDox3AbwfUhD0/1IvohyTutOIFoc=
 github.com/schollz/progressbar/v3 v3.19.0/go.mod h1:IsO3lpbaGuzh8zIMzgY3+J8l4C8GjO0Y9S69eFvNsec=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/pkg/box/fetch.go
+++ b/pkg/box/fetch.go
@@ -284,7 +284,7 @@ func SaveBox(_ context.Context, s *Storage) error {
 // downloads it and then saves it to disk. In general EnsureBox
 // should be used over this function.
 func InitializeBox(ctx context.Context, _ []string) error {
-	gitRepo, err := prompt.Ask(prompt.Config{
+	gitRepo, err := prompt.Ask(ctx, prompt.Config{
 		Message: "Please enter your box configuration git URL",
 		Help:    "This is the repository that contains your box.yaml and will be used for outreach tooling",
 	})

--- a/pkg/cli/prompt/confirm_test.go
+++ b/pkg/cli/prompt/confirm_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+package prompt
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestConfirmModel(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  ConfirmConfig
+		keys []tea.KeyPressMsg
+		want bool
+	}{
+		{name: "y confirms", cfg: ConfirmConfig{Message: "test"}, keys: []tea.KeyPressMsg{keypress('y')}, want: true},
+		{name: "n declines", cfg: ConfirmConfig{Message: "test"}, keys: []tea.KeyPressMsg{keypress('n')}, want: false},
+		{
+			name: "enter alone uses Default=false",
+			cfg:  ConfirmConfig{Message: "test", Default: false},
+			keys: []tea.KeyPressMsg{codeKeypress(tea.KeyEnter)},
+			want: false,
+		},
+		{
+			name: "enter alone uses Default=true",
+			cfg:  ConfirmConfig{Message: "test", Default: true},
+			keys: []tea.KeyPressMsg{codeKeypress(tea.KeyEnter)},
+			want: true,
+		},
+		{
+			name: "left is idempotent: pressing it twice still lands on Yes",
+			cfg:  ConfirmConfig{Message: "test", Default: false},
+			keys: []tea.KeyPressMsg{
+				codeKeypress(tea.KeyLeft), codeKeypress(tea.KeyLeft), codeKeypress(tea.KeyEnter),
+			},
+			want: true,
+		},
+		{
+			name: "right is idempotent: pressing it twice still lands on No",
+			cfg:  ConfirmConfig{Message: "test", Default: true},
+			keys: []tea.KeyPressMsg{
+				codeKeypress(tea.KeyRight), codeKeypress(tea.KeyRight), codeKeypress(tea.KeyEnter),
+			},
+			want: false,
+		},
+		{
+			name: "tab moves off Default=true onto No",
+			cfg:  ConfirmConfig{Message: "test", Default: true},
+			keys: []tea.KeyPressMsg{codeKeypress(tea.KeyTab), codeKeypress(tea.KeyEnter)},
+			want: false,
+		},
+		{
+			name: "y overrides a highlighted No",
+			cfg:  ConfirmConfig{Message: "test", Default: false},
+			keys: []tea.KeyPressMsg{keypress('y')},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newConfirmModel(tt.cfg)
+			for _, key := range tt.keys {
+				m.Update(key)
+			}
+
+			if got := m.cursor == 0; got != tt.want {
+				t.Errorf("confirmed = %v, want %v", got, tt.want)
+			}
+			if m.err != nil {
+				t.Errorf("err = %v, want nil", m.err)
+			}
+		})
+	}
+}
+
+func TestConfirmModelAbort(t *testing.T) {
+	t.Run("ctrl+c aborts", func(t *testing.T) {
+		m := newConfirmModel(ConfirmConfig{Message: "test"})
+		m.Update(ctrlCKeypress())
+
+		if !errors.Is(m.err, ErrAborted) {
+			t.Errorf("err = %v, want ErrAborted", m.err)
+		}
+	})
+
+	t.Run("esc aborts", func(t *testing.T) {
+		m := newConfirmModel(ConfirmConfig{Message: "test"})
+		m.Update(codeKeypress(tea.KeyEscape))
+
+		if !errors.Is(m.err, ErrAborted) {
+			t.Errorf("err = %v, want ErrAborted", m.err)
+		}
+	})
+}

--- a/pkg/cli/prompt/input_test.go
+++ b/pkg/cli/prompt/input_test.go
@@ -23,6 +23,25 @@ func TestInputModel(t *testing.T) {
 		}
 	})
 
+	t.Run("default is used unmodified on bare enter", func(t *testing.T) {
+		m := newInputModel(Config{Message: "test", Default: "octocat"})
+		m.Update(codeKeypress(tea.KeyEnter))
+
+		if got := m.input.Value(); got != "octocat" {
+			t.Errorf("Value() = %q, want %q", got, "octocat")
+		}
+	})
+
+	t.Run("default can be edited before submit", func(t *testing.T) {
+		m := newInputModel(Config{Message: "test", Default: "octocat"})
+		typeString(m, "-fork")
+		m.Update(codeKeypress(tea.KeyEnter))
+
+		if got := m.input.Value(); got != "octocat-fork" {
+			t.Errorf("Value() = %q, want %q", got, "octocat-fork")
+		}
+	})
+
 	t.Run("ctrl+c aborts", func(t *testing.T) {
 		m := newInputModel(Config{Message: "test"})
 		m.Update(ctrlCKeypress())

--- a/pkg/cli/prompt/multiselect_test.go
+++ b/pkg/cli/prompt/multiselect_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+package prompt
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestMultiSelectModel(t *testing.T) {
+	options := []string{"a", "b", "c"}
+
+	t.Run("space toggles options on, in listed order", func(t *testing.T) {
+		m := newMultiSelectModel(MultiSelectConfig{Options: options})
+		m.Update(codeKeypress(tea.KeySpace))
+		m.Update(codeKeypress(tea.KeyDown))
+		m.Update(codeKeypress(tea.KeyDown))
+		m.Update(codeKeypress(tea.KeySpace))
+		m.Update(codeKeypress(tea.KeyEnter))
+
+		var got []string
+		for i, opt := range m.cfg.Options {
+			if m.selected[i] {
+				got = append(got, opt)
+			}
+		}
+		if want := []string{"a", "c"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("selected = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("space toggles an option back off", func(t *testing.T) {
+		m := newMultiSelectModel(MultiSelectConfig{Options: options})
+		m.Update(codeKeypress(tea.KeySpace))
+		m.Update(codeKeypress(tea.KeySpace))
+
+		if m.selected[0] {
+			t.Error("selected[0] = true, want false after toggling twice")
+		}
+	})
+
+	t.Run("ctrl+c aborts", func(t *testing.T) {
+		m := newMultiSelectModel(MultiSelectConfig{Options: options})
+		m.Update(ctrlCKeypress())
+
+		if !errors.Is(m.err, ErrAborted) {
+			t.Errorf("err = %v, want ErrAborted", m.err)
+		}
+	})
+
+	t.Run("esc aborts", func(t *testing.T) {
+		m := newMultiSelectModel(MultiSelectConfig{Options: options})
+		m.Update(codeKeypress(tea.KeyEscape))
+
+		if !errors.Is(m.err, ErrAborted) {
+			t.Errorf("err = %v, want ErrAborted", m.err)
+		}
+	})
+}
+
+func TestMultiSelectNoOptions(t *testing.T) {
+	// No options is rejected before a Program is ever started, so this is
+	// safe to call directly without a TTY.
+	if _, err := MultiSelect(t.Context(), MultiSelectConfig{}); !errors.Is(err, ErrAborted) {
+		t.Errorf("err = %v, want ErrAborted", err)
+	}
+}

--- a/pkg/cli/prompt/pickone_test.go
+++ b/pkg/cli/prompt/pickone_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+package prompt
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/list"
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestNewPickerModel(t *testing.T) {
+	options := []Option[string]{
+		{Label: "current", Description: "cannot pick this", Disabled: true, Value: "current"},
+		{Label: "older", Value: "older"},
+	}
+
+	m := newPickerModel("title", options)
+
+	items := m.list.Items()
+	if len(items) != len(options) {
+		t.Fatalf("got %d items, want %d", len(items), len(options))
+	}
+
+	for i, listItem := range items {
+		item, ok := listItem.(pickerItem[string])
+		if !ok {
+			t.Fatalf("item %d has type %T, want pickerItem[string]", i, listItem)
+		}
+		if item.label != options[i].Label {
+			t.Errorf("item %d: label = %q, want %q", i, item.label, options[i].Label)
+		}
+		if item.disabled != options[i].Disabled {
+			t.Errorf("item %d: disabled = %v, want %v", i, item.disabled, options[i].Disabled)
+		}
+		if item.value != options[i].Value {
+			t.Errorf("item %d: value = %q, want %q", i, item.value, options[i].Value)
+		}
+	}
+}
+
+func TestPickerModel(t *testing.T) {
+	type item struct{ n int }
+
+	newOptions := func() []Option[item] {
+		return []Option[item]{
+			{Label: "current", Description: "cannot pick", Disabled: true, Value: item{1}},
+			{Label: "older", Value: item{2}},
+			{Label: "oldest", Value: item{3}},
+		}
+	}
+
+	t.Run("enter picks the highlighted option", func(t *testing.T) {
+		m := newPickerModel("Choose", newOptions())
+		m.Update(codeKeypress(tea.KeyDown))
+		m.Update(codeKeypress(tea.KeyEnter))
+
+		if m.chosen == nil {
+			t.Fatal("chosen = nil, want a picked item")
+		}
+		if m.chosen.value.n != 2 {
+			t.Errorf("chosen.value = %+v, want {n:2}", m.chosen.value)
+		}
+	})
+
+	t.Run("enter on a disabled option does not pick it", func(t *testing.T) {
+		m := newPickerModel("Choose", newOptions())
+		m.Update(codeKeypress(tea.KeyEnter))
+
+		if m.chosen != nil {
+			t.Fatalf("chosen = %+v, want nil (option is disabled)", m.chosen)
+		}
+
+		m.Update(codeKeypress(tea.KeyDown))
+		m.Update(codeKeypress(tea.KeyEnter))
+
+		if m.chosen == nil {
+			t.Fatal("chosen = nil, want a picked item after moving off the disabled option")
+		}
+		if m.chosen.value.n != 2 {
+			t.Errorf("chosen.value = %+v, want {n:2}", m.chosen.value)
+		}
+	})
+
+	t.Run("ctrl+c cancels without picking", func(t *testing.T) {
+		m := newPickerModel("Choose", newOptions())
+		m.Update(ctrlCKeypress())
+
+		if m.chosen != nil {
+			t.Errorf("chosen = %+v, want nil", m.chosen)
+		}
+	})
+
+	t.Run("esc cancels without picking", func(t *testing.T) {
+		m := newPickerModel("Choose", newOptions())
+		m.Update(codeKeypress(tea.KeyEscape))
+
+		if m.chosen != nil {
+			t.Errorf("chosen = %+v, want nil", m.chosen)
+		}
+	})
+
+	t.Run("slash enters filtering mode", func(t *testing.T) {
+		m := newPickerModel("Choose", newOptions())
+		m.Update(keypress('/'))
+
+		if got := m.list.FilterState(); got != list.Filtering {
+			t.Errorf("FilterState() = %v, want Filtering", got)
+		}
+	})
+
+	t.Run("ctrl+c quits even while filtering, unlike esc and enter", func(t *testing.T) {
+		m := newPickerModel("Choose", newOptions())
+		m.Update(keypress('/'))
+		if got := m.list.FilterState(); got != list.Filtering {
+			t.Fatalf("FilterState() = %v, want Filtering", got)
+		}
+
+		_, cmd := m.Update(ctrlCKeypress())
+		if cmd == nil {
+			t.Fatal("expected a quit command, got nil")
+		}
+		if msg := cmd(); msg != (tea.QuitMsg{}) {
+			t.Errorf("cmd() = %#v, want tea.QuitMsg{}", msg)
+		}
+	})
+}

--- a/pkg/cli/prompt/prompt.go
+++ b/pkg/cli/prompt/prompt.go
@@ -1,24 +1,28 @@
 // Copyright 2026 Outreach Corporation. All Rights Reserved.
 
-// Description: Provides minimal single-field interactive terminal prompts
-// built on Bubble Tea, replacing the archived AlecAivazis/survey package.
+// Description: Provides minimal interactive terminal prompts built on
+// Bubble Tea, replacing the archived AlecAivazis/survey package.
 
-// Package prompt implements small, single-field terminal prompts (e.g. for a
-// URL or a password) on top of github.com/charmbracelet/bubbletea.
+// Package prompt implements small terminal prompts (text input, yes/no
+// confirmation, single- and multi-choice selection, and a filterable,
+// generic picker) on top of github.com/charmbracelet/bubbletea.
 package prompt
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
+	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 )
 
-// ErrAborted is returned by Ask when the user cancels the prompt, e.g. via
-// Ctrl+C or Esc.
+// ErrAborted is returned when the user cancels a prompt, e.g. via Ctrl+C
+// or Esc. It is not used by PickOne, which signals cancellation through
+// its own ok return value instead; see PickOne's doc comment.
 var ErrAborted = errors.New("prompt aborted")
 
 // Key names matched against tea.KeyPressMsg.String() across every model
@@ -38,6 +42,19 @@ func Required(s string) error {
 	return nil
 }
 
+var (
+	messageStyle  = lipgloss.NewStyle().Bold(true)
+	helpStyle     = lipgloss.NewStyle().Faint(true)
+	errorStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+	selectedStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212"))
+
+	// confirmFocusedStyle and confirmBlurredStyle render the highlighted
+	// and non-highlighted Yes/No buttons for Confirm.
+	confirmFocusedStyle = lipgloss.NewStyle().Bold(true).Padding(0, 2).
+				Background(lipgloss.Color("57")).Foreground(lipgloss.Color("230"))
+	confirmBlurredStyle = lipgloss.NewStyle().Padding(0, 2).Foreground(lipgloss.Color("240"))
+)
+
 // Config describes a single-field text prompt.
 type Config struct {
 	// Message is the question shown to the user.
@@ -45,6 +62,10 @@ type Config struct {
 
 	// Help, if set, is displayed underneath the message.
 	Help string
+
+	// Default, if set, pre-fills the input. The user can edit or clear
+	// it before submitting.
+	Default string
 
 	// EchoMode controls how typed input is displayed, e.g.
 	// textinput.EchoPassword to mask the input. Defaults to
@@ -57,13 +78,6 @@ type Config struct {
 	Validate func(string) error
 }
 
-var (
-	messageStyle  = lipgloss.NewStyle().Bold(true)
-	helpStyle     = lipgloss.NewStyle().Faint(true)
-	errorStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-	selectedStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212"))
-)
-
 // inputModel is the Bubble Tea model backing Ask.
 type inputModel struct {
 	cfg     Config
@@ -72,11 +86,15 @@ type inputModel struct {
 	err     error
 }
 
-// newInputModel builds an inputModel for cfg and focuses the field.
+// newInputModel builds an inputModel for cfg, pre-filling Default (if
+// set) and focusing the field.
 func newInputModel(cfg Config) *inputModel {
 	ti := textinput.New()
 	ti.Prompt = "> "
 	ti.EchoMode = cfg.EchoMode
+	if cfg.Default != "" {
+		ti.SetValue(cfg.Default)
+	}
 
 	return &inputModel{cfg: cfg, input: ti, initCmd: ti.Focus()}
 }
@@ -126,9 +144,10 @@ func (m *inputModel) View() tea.View {
 }
 
 // Ask displays a single-field terminal prompt and returns the entered
-// value. It returns ErrAborted if the user cancels the prompt.
-func Ask(cfg Config) (string, error) {
-	finalModel, err := tea.NewProgram(newInputModel(cfg)).Run()
+// value. It returns ErrAborted if the user cancels the prompt, or if ctx
+// is canceled while the prompt is running.
+func Ask(ctx context.Context, cfg Config) (string, error) {
+	finalModel, err := tea.NewProgram(newInputModel(cfg), tea.WithContext(ctx)).Run()
 	if err != nil {
 		return "", fmt.Errorf("running input prompt: %w", err)
 	}
@@ -212,14 +231,14 @@ func (m *selectModel) View() tea.View {
 }
 
 // Select displays a single-choice terminal prompt and returns the chosen
-// option. It returns ErrAborted if the user cancels the prompt, or if no
-// options are provided.
-func Select(cfg SelectConfig) (string, error) {
+// option. It returns ErrAborted if the user cancels the prompt, if ctx is
+// canceled while the prompt is running, or if no options are provided.
+func Select(ctx context.Context, cfg SelectConfig) (string, error) {
 	if len(cfg.Options) == 0 {
 		return "", ErrAborted
 	}
 
-	finalModel, err := tea.NewProgram(&selectModel{cfg: cfg}).Run()
+	finalModel, err := tea.NewProgram(&selectModel{cfg: cfg}, tea.WithContext(ctx)).Run()
 	if err != nil {
 		return "", fmt.Errorf("running selection prompt: %w", err)
 	}
@@ -230,4 +249,352 @@ func Select(cfg SelectConfig) (string, error) {
 	}
 
 	return m.cfg.Options[m.cursor], nil
+}
+
+// MultiSelectConfig describes a multiple-choice prompt.
+type MultiSelectConfig struct {
+	// Message is the question shown to the user.
+	Message string
+
+	// Help, if set, is displayed underneath the message.
+	Help string
+
+	// Options are the choices presented to the user. Toggle an option
+	// with Space, move with the up/down (or j/k) arrow keys, and confirm
+	// the current set of selections with Enter.
+	Options []string
+}
+
+// multiSelectModel is the Bubble Tea model backing MultiSelect.
+type multiSelectModel struct {
+	cfg      MultiSelectConfig
+	cursor   int
+	selected map[int]bool
+	err      error
+}
+
+// newMultiSelectModel builds a multiSelectModel for cfg, with every
+// option initially unselected.
+func newMultiSelectModel(cfg MultiSelectConfig) *multiSelectModel {
+	return &multiSelectModel{cfg: cfg, selected: make(map[int]bool, len(cfg.Options))}
+}
+
+func (m *multiSelectModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles a key press: ctrl+c and esc abort; up/k and down/j
+// move the cursor; space toggles the highlighted option; enter
+// confirms the current set of selections.
+func (m *multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		switch keyMsg.String() {
+		case keyCtrlC, keyEsc:
+			m.err = ErrAborted
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.cfg.Options)-1 {
+				m.cursor++
+			}
+		case "space":
+			m.selected[m.cursor] = !m.selected[m.cursor]
+		case keyEnter:
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m *multiSelectModel) View() tea.View {
+	var b strings.Builder
+
+	fmt.Fprintln(&b, messageStyle.Render(m.cfg.Message))
+	if m.cfg.Help != "" {
+		fmt.Fprintln(&b, helpStyle.Render(m.cfg.Help))
+	}
+
+	for i, opt := range m.cfg.Options {
+		marker := "  "
+		box := "[ ]"
+		style := lipgloss.NewStyle()
+		if m.selected[i] {
+			box = "[x]"
+		}
+		if i == m.cursor {
+			marker = "> "
+			style = selectedStyle
+		}
+		fmt.Fprintf(&b, "%s%s %s\n", marker, box, style.Render(opt))
+	}
+	fmt.Fprintln(&b, helpStyle.Render("(space to toggle, enter to confirm)"))
+
+	return tea.NewView(b.String())
+}
+
+// MultiSelect displays a multiple-choice terminal prompt and returns the
+// chosen options, in the order they were listed in cfg.Options. It
+// returns ErrAborted if the user cancels the prompt, if ctx is canceled
+// while the prompt is running, or if no options are provided.
+func MultiSelect(ctx context.Context, cfg MultiSelectConfig) ([]string, error) {
+	if len(cfg.Options) == 0 {
+		return nil, ErrAborted
+	}
+
+	finalModel, err := tea.NewProgram(newMultiSelectModel(cfg), tea.WithContext(ctx)).Run()
+	if err != nil {
+		return nil, fmt.Errorf("running multi-select prompt: %w", err)
+	}
+
+	m := finalModel.(*multiSelectModel) //nolint:forcetypeassert // Why: we control the only model given to this Program.
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	var result []string
+	for i, opt := range m.cfg.Options {
+		if m.selected[i] {
+			result = append(result, opt)
+		}
+	}
+
+	return result, nil
+}
+
+// ConfirmConfig describes a yes/no confirmation prompt.
+type ConfirmConfig struct {
+	// Message is the question shown to the user.
+	Message string
+
+	// Help, if set, is displayed underneath the message.
+	Help string
+
+	// Default is the choice highlighted initially, and the one used when
+	// the user presses Enter without typing y/n explicitly.
+	Default bool
+}
+
+// confirmModel is the Bubble Tea model backing Confirm.
+type confirmModel struct {
+	cfg    ConfirmConfig
+	cursor int // 0 = Yes, 1 = No
+	err    error
+}
+
+// newConfirmModel builds a confirmModel for cfg, with the cursor
+// starting on cfg.Default.
+func newConfirmModel(cfg ConfirmConfig) *confirmModel {
+	cursor := 1
+	if cfg.Default {
+		cursor = 0
+	}
+
+	return &confirmModel{cfg: cfg, cursor: cursor}
+}
+
+func (m *confirmModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles a key press. y/Y and n/N answer directly; left/h and
+// right/l/tab move the highlight between Yes and No; enter answers with
+// the highlighted choice.
+func (m *confirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		switch keyMsg.String() {
+		case keyCtrlC, keyEsc:
+			m.err = ErrAborted
+			return m, tea.Quit
+		case "y", "Y":
+			m.cursor = 0
+			return m, tea.Quit
+		case "n", "N":
+			m.cursor = 1
+			return m, tea.Quit
+		case "left", "h":
+			m.cursor = 0
+		case "right", "l", "tab":
+			m.cursor = 1
+		case keyEnter:
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m *confirmModel) View() tea.View {
+	yesStyle, noStyle := confirmBlurredStyle, confirmFocusedStyle
+	if m.cursor == 0 {
+		yesStyle, noStyle = confirmFocusedStyle, confirmBlurredStyle
+	}
+
+	var b strings.Builder
+	fmt.Fprintln(&b, messageStyle.Render(m.cfg.Message))
+	if m.cfg.Help != "" {
+		fmt.Fprintln(&b, helpStyle.Render(m.cfg.Help))
+	}
+	fmt.Fprintf(&b, "%s %s\n", yesStyle.Render("Yes"), noStyle.Render("No"))
+
+	return tea.NewView(b.String())
+}
+
+// Confirm displays a yes/no terminal prompt and returns the user's
+// choice. Pressing Enter without typing y/n returns cfg.Default. It
+// returns ErrAborted if the user cancels the prompt, or if ctx is
+// canceled while the prompt is running.
+func Confirm(ctx context.Context, cfg ConfirmConfig) (bool, error) {
+	finalModel, err := tea.NewProgram(newConfirmModel(cfg), tea.WithContext(ctx)).Run()
+	if err != nil {
+		return false, fmt.Errorf("running confirmation prompt: %w", err)
+	}
+
+	m := finalModel.(*confirmModel) //nolint:forcetypeassert // Why: we control the only model given to this Program.
+	if m.err != nil {
+		return false, m.err
+	}
+
+	return m.cursor == 0, nil
+}
+
+// Option is one choice in a PickOne list.
+type Option[T any] struct {
+	// Label is the option's main text.
+	Label string
+
+	// Description is a second line of text under Label.
+	Description string
+
+	// Disabled options show in the list, but the user cannot pick them.
+	// Description, if set, explains why.
+	Disabled bool
+
+	// Value is the value PickOne returns for this option.
+	Value T
+}
+
+// pickerItem adapts an Option for use as a charm.land/bubbles/v2/list item.
+type pickerItem[T any] struct {
+	label       string
+	description string
+	disabled    bool
+	value       T
+}
+
+// FilterValue returns the text the list filters against.
+func (i pickerItem[T]) FilterValue() string { return i.label }
+
+// Title returns the option's main line of text.
+func (i pickerItem[T]) Title() string { return i.label }
+
+// Description returns the option's second line of text.
+func (i pickerItem[T]) Description() string { return i.description }
+
+// pickerModel is the Bubble Tea model backing PickOne.
+type pickerModel[T any] struct {
+	list   list.Model
+	chosen *pickerItem[T]
+}
+
+// newPickerModel builds a pickerModel listing options, in order, under
+// title.
+func newPickerModel[T any](title string, options []Option[T]) *pickerModel[T] {
+	items := make([]list.Item, len(options))
+	for i, o := range options {
+		items[i] = pickerItem[T]{label: o.Label, description: o.Description, disabled: o.Disabled, value: o.Value}
+	}
+
+	// 80x20 is a placeholder size for the first frame. Bubble Tea sends
+	// the real terminal size in a tea.WindowSizeMsg right after startup,
+	// and Update resizes the list once that arrives.
+	l := list.New(items, list.NewDefaultDelegate(), 80, 20)
+	l.Title = title
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(true)
+
+	return &pickerModel[T]{list: l}
+}
+
+func (m *pickerModel[T]) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles list navigation and filtering, plus keys this model
+// adds on top: ctrl+c always cancels, even mid-filter; esc cancels
+// outside of filtering (bubbles/list's own esc-cancels-the-filter
+// behavior takes over while filtering); and enter picks the highlighted
+// option (or, if it's disabled, shows a status message instead of
+// picking it).
+func (m *pickerModel[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.list.SetSize(msg.Width, msg.Height)
+		return m, nil
+	case tea.KeyPressMsg:
+		if msg.String() == keyCtrlC {
+			return m, tea.Quit
+		}
+
+		if m.list.FilterState() != list.Filtering {
+			switch msg.String() {
+			case keyEsc:
+				return m, tea.Quit
+			case keyEnter:
+				item, ok := m.list.SelectedItem().(pickerItem[T])
+				if !ok {
+					return m, nil
+				}
+				if item.disabled {
+					message := item.description
+					if message == "" {
+						message = "This option cannot be picked."
+					}
+					return m, m.list.NewStatusMessage(message)
+				}
+				m.chosen = &item
+				return m, tea.Quit
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m *pickerModel[T]) View() tea.View {
+	return tea.NewView(m.list.View())
+}
+
+// PickOne shows options in an interactive, filterable list, under the
+// given title. Type "/" to filter the list, use the arrow keys to move,
+// and press enter to pick the highlighted option. Disabled options
+// cannot be picked.
+//
+// PickOne returns the Value of the picked option. ok is false if the
+// user canceled instead of picking an option (via Esc or Ctrl+C); this
+// is not reported as an error. Canceling ctx also cancels the picker;
+// PickOne then returns a non-nil error.
+func PickOne[T any](ctx context.Context, title string, options []Option[T]) (value T, ok bool, err error) {
+	finalModel, err := tea.NewProgram(newPickerModel(title, options), tea.WithContext(ctx)).Run()
+	if err != nil {
+		var zero T
+		return zero, false, fmt.Errorf("running picker: %w", err)
+	}
+
+	m, modelOK := finalModel.(*pickerModel[T])
+	if !modelOK {
+		var zero T
+		return zero, false, fmt.Errorf("picker returned model of type %T", finalModel)
+	}
+	if m.chosen == nil {
+		var zero T
+		return zero, false, nil
+	}
+
+	return m.chosen.value, true, nil
 }

--- a/pkg/cli/prompt/select_test.go
+++ b/pkg/cli/prompt/select_test.go
@@ -75,7 +75,7 @@ func TestSelectModel(t *testing.T) {
 func TestSelectNoOptions(t *testing.T) {
 	// No options is rejected before a Program is ever started, so this is
 	// safe to call directly without a TTY.
-	if _, err := Select(SelectConfig{}); !errors.Is(err, ErrAborted) {
+	if _, err := Select(t.Context(), SelectConfig{}); !errors.Is(err, ErrAborted) {
 		t.Errorf("err = %v, want ErrAborted", err)
 	}
 }

--- a/pkg/cli/updater/misc.go
+++ b/pkg/cli/updater/misc.go
@@ -4,6 +4,7 @@
 package updater
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"runtime/debug"
@@ -34,7 +35,7 @@ func getRepoFromBuild() (string, error) {
 
 // handleMajorVersion prompts the user when a new major version is available, returns
 // true if we should continue, or false if we shouldn't
-func handleMajorVersion(log logrus.FieldLogger, curV, newV, relNotes string) bool {
+func handleMajorVersion(ctx context.Context, log logrus.FieldLogger, curV, newV, relNotes string) bool {
 	// we skip errors because the above logic already parsed these version strings
 	cver, err := semver.NewVersion(curV)
 	if err != nil {
@@ -65,7 +66,7 @@ func handleMajorVersion(log logrus.FieldLogger, curV, newV, relNotes string) boo
 	fmt.Println(out)
 
 	log.Infof("Detected major version upgrade (%d -> %d). Would you like to upgrade?", cver.Major, nver.Major)
-	resp, err := prompt.Select(prompt.SelectConfig{
+	resp, err := prompt.Select(ctx, prompt.SelectConfig{
 		Message: "Select",
 		Options: []string{"Yes", "No"},
 	})

--- a/pkg/cli/updater/updater.go
+++ b/pkg/cli/updater/updater.go
@@ -356,7 +356,7 @@ func (u *updater) check(ctx context.Context) (bool, error) {
 
 	// handle major versions by prompting the user if this is one
 	if !u.skipMajorVersionPrompt {
-		if shouldContinue := handleMajorVersion(u.log, u.version, v.String(), relNotes); !shouldContinue {
+		if shouldContinue := handleMajorVersion(ctx, u.log, u.version, v.String(), relNotes); !shouldContinue {
 			return false, nil
 		}
 	}

--- a/pkg/sshhelper/sshhelper.go
+++ b/pkg/sshhelper/sshhelper.go
@@ -127,7 +127,7 @@ func AddKeyToAgent(keyPath string, a agent.Agent, log logrus.FieldLogger) error 
 
 		for {
 			if pass, err = keyring.Get(serviceName, user); err != nil {
-				pass, err = prompt.Ask(prompt.Config{
+				pass, err = prompt.Ask(context.Background(), prompt.Config{
 					Message:  "Please enter your SSH Key Password:",
 					Help:     fmt.Sprintf("SSH Key: %s", keyPath),
 					EchoMode: textinput.EchoPassword,


### PR DESCRIPTION
## What this PR does / why we need it

Rounds out `pkg/cli/prompt` (added in #816) with the rest of what `survey` offered, plus more: `Confirm` (yes/no), `MultiSelect` (checkbox-style multi-choice), and a generic, filterable `PickOne[T]` picker, plus a `Default` value for `Ask` and `context.Context` support on every prompt so a caller can cancel one mid-run. None of these have a caller in this repo yet — they exist so other internal tooling still on `survey`, or on hand-rolled Bubble Tea prompts, can adopt this package instead of maintaining its own.

## Notes for your reviewers

`PickOne`'s cancellation semantics deliberately differ from the rest of the package: it signals a user cancel through its `ok` return value rather than an error, to match an existing internal API it's meant to replace.

---
_Generated by [Claude Code](https://claude.ai/code/session_017CSNxsMvkXnJM5RdieLES8)_