### PR TITLE
feat(cli): replace progressbar/spinner deps with Bubble Tea

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
-	github.com/schollz/progressbar/v3 v3.19.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/ulikunitz/xz v0.5.16
 	github.com/urfave/cli/v2 v2.27.7
@@ -59,6 +58,7 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
+	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
@@ -112,7 +112,6 @@ require (
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
-	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/briandowns/spinner v1.23.2
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/log v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
 github.com/charmbracelet/glamour v1.0.0 h1:AWMLOVFHTsysl4WV8T8QgkQ0s/ZNZo7CiE4WKhk8l08=
 github.com/charmbracelet/glamour v1.0.0/go.mod h1:DSdohgOBkMr2ZQNhw4LZxSGpx3SvpeujNoXrQyH2hxo=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
 github.com/charmbracelet/log v1.0.0 h1:HVVVMmfOorfj3BA9i8X8UL69Hoz9lI0PYwXfJvOdRc4=
@@ -63,8 +65,6 @@ github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8
 github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
 github.com/charmbracelet/x/windows v0.2.2 h1:IofanmuvaxnKHuV04sC0eBy/smG6kIKrWG2/jYn2GuM=
 github.com/charmbracelet/x/windows v0.2.2/go.mod h1:/8XtdKZzedat74NQFn0NGlGL4soHB0YQZrETF96h75k=
-github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
-github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
@@ -170,8 +170,6 @@ github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/a
 github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
-github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
-github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -214,8 +212,6 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sahilm/fuzzy v0.1.3 h1:juByESSS32nVD81vr6tHmKmA/8zde7gE+x5CLxrzXPU=
 github.com/sahilm/fuzzy v0.1.3/go.mod h1:au6//VbVSqu6DFrkL2CfjlJ5iURpNCPeE+1GwY3XsT8=
-github.com/schollz/progressbar/v3 v3.19.1 h1:iv8BgwOvdML/S3p84uBpy/IMigv4U9594vPZYa2EdrU=
-github.com/schollz/progressbar/v3 v3.19.1/go.mod h1:LFL7jqimKxfhero4K1eCkUr/6R39AgQeiPCJtlTWIW8=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
-github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/cli/internal/term/term.go
+++ b/pkg/cli/internal/term/term.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+// Description: Shared terminal-output helpers for pkg/cli's Bubble Tea
+// based line writers (progress, spinner).
+
+// Package term holds small terminal-output helpers shared by pkg/cli's
+// progress and spinner packages.
+package term
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// ClearLine is the ANSI escape sequence that returns the cursor to the
+// start of the current line and erases it, used to redraw a status line
+// in place.
+const ClearLine = "\r\033[K"
+
+// IsTerminal reports whether f is connected to a terminal.
+func IsTerminal(f *os.File) bool {
+	return term.IsTerminal(int(f.Fd()))
+}

--- a/pkg/cli/internal/term/term.go
+++ b/pkg/cli/internal/term/term.go
@@ -22,3 +22,15 @@ const ClearLine = "\r\033[K"
 func IsTerminal(f *os.File) bool {
 	return term.IsTerminal(int(f.Fd()))
 }
+
+// Width returns f's current terminal column width, and whether it could
+// be determined at all (e.g. f might not be a terminal). Callers that
+// redraw a line in place should re-check this on every redraw rather
+// than caching it, so output keeps fitting the terminal across resizes.
+func Width(f *os.File) (width int, ok bool) {
+	w, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || w <= 0 {
+		return 0, false
+	}
+	return w, true
+}

--- a/pkg/cli/internal/term/term_test.go
+++ b/pkg/cli/internal/term/term_test.go
@@ -5,22 +5,18 @@ package term
 import (
 	"os"
 	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 func TestIsTerminalFalseForRegularFile(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "term-test")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	t.Cleanup(func() { f.Close() }) //nolint:errcheck // Why: Best effort
+	assert.NilError(t, err)
+	t.Cleanup(func() { assert.NilError(t, f.Close()) })
 
-	if IsTerminal(f) {
-		t.Error("IsTerminal(regular file) = true, want false")
-	}
+	assert.Equal(t, IsTerminal(f), false)
 }
 
 func TestClearLine(t *testing.T) {
-	if want := "\r\033[K"; ClearLine != want {
-		t.Errorf("ClearLine = %q, want %q", ClearLine, want)
-	}
+	assert.Equal(t, ClearLine, "\r\033[K")
 }

--- a/pkg/cli/internal/term/term_test.go
+++ b/pkg/cli/internal/term/term_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+package term
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsTerminalFalseForRegularFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "term-test")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer f.Close() //nolint:errcheck // Why: Best effort
+
+	if IsTerminal(f) {
+		t.Error("IsTerminal(regular file) = true, want false")
+	}
+}
+
+func TestClearLine(t *testing.T) {
+	if want := "\r\033[K"; ClearLine != want {
+		t.Errorf("ClearLine = %q, want %q", ClearLine, want)
+	}
+}

--- a/pkg/cli/internal/term/term_test.go
+++ b/pkg/cli/internal/term/term_test.go
@@ -12,7 +12,7 @@ func TestIsTerminalFalseForRegularFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTemp: %v", err)
 	}
-	defer f.Close() //nolint:errcheck // Why: Best effort
+	t.Cleanup(func() { f.Close() }) //nolint:errcheck // Why: Best effort
 
 	if IsTerminal(f) {
 		t.Error("IsTerminal(regular file) = true, want false")

--- a/pkg/cli/logfile/logfile_unix.go
+++ b/pkg/cli/logfile/logfile_unix.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/getoutreach/gobox/pkg/app"
+	cliterm "github.com/getoutreach/gobox/pkg/cli/internal/term"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"golang.org/x/term"
@@ -34,7 +35,7 @@ func Hook() error {
 	}
 
 	// if both stdin and stdout are not terminals, then we don't need a pty
-	isTerminal := term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+	isTerminal := cliterm.IsTerminal(os.Stdin) && cliterm.IsTerminal(os.Stdout)
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -166,7 +167,7 @@ func forwardSignals(exited <-chan struct{}, ptmx *os.File, cmd *exec.Cmd) {
 // attachStdinToPty attaches the current os.Stdin to the
 // provided PTY if running in a terminal
 func attachStdinToPty() (func(), error) {
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
+	if !cliterm.IsTerminal(os.Stdin) {
 		return func() {}, nil
 	}
 

--- a/pkg/cli/progress/progress.go
+++ b/pkg/cli/progress/progress.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	barprogress "charm.land/bubbles/v2/progress"
-	"golang.org/x/term"
+	"github.com/getoutreach/gobox/pkg/cli/internal/term"
 )
 
 const (
@@ -45,6 +45,7 @@ const (
 type Bytes struct {
 	description string
 	total       int64
+	totalStr    string
 	isTerm      bool
 	bar         barprogress.Model
 	out         io.Writer
@@ -60,13 +61,21 @@ type Bytes struct {
 // (pass <= 0 if the size isn't known ahead of time), labeled with
 // description.
 func NewBytes(total int64, description string) *Bytes {
+	return newBytes(total, description, os.Stderr, term.IsTerminal(os.Stderr), time.Now)
+}
+
+// newBytes builds a Bytes with explicit out/isTerm/now, so tests can
+// substitute a buffer and a controllable clock without going through
+// NewBytes' os.Stderr/time.Now defaults.
+func newBytes(total int64, description string, out io.Writer, isTerm bool, now func() time.Time) *Bytes {
 	b := &Bytes{
 		description: description,
 		total:       total,
-		isTerm:      term.IsTerminal(int(os.Stderr.Fd())),
+		totalStr:    formatBytes(total),
+		isTerm:      isTerm,
 		bar:         barprogress.New(barprogress.WithDefaultBlend()),
-		out:         os.Stderr,
-		now:         time.Now,
+		out:         out,
+		now:         now,
 	}
 	b.start = b.now()
 	return b
@@ -113,15 +122,22 @@ func (b *Bytes) draw(force bool) {
 		rate = int64(float64(b.written) / elapsed)
 	}
 
-	line := fmt.Sprintf("%s %s  %s/s", b.description, formatBytes(b.written), formatBytes(rate))
-	if b.total > 0 {
+	var line string
+	switch {
+	case b.total > 0 && b.isTerm:
+		// The styled bar is only worth rendering when it'll actually be
+		// shown; skip it in the plain, non-terminal case below.
 		percent := min(1, float64(b.written)/float64(b.total))
 		line = fmt.Sprintf("%s %s  %s/%s  %s/s",
-			b.description, b.bar.ViewAs(percent), formatBytes(b.written), formatBytes(b.total), formatBytes(rate))
+			b.description, b.bar.ViewAs(percent), formatBytes(b.written), b.totalStr, formatBytes(rate))
+	case b.total > 0:
+		line = fmt.Sprintf("%s %s/%s  %s/s", b.description, formatBytes(b.written), b.totalStr, formatBytes(rate))
+	default:
+		line = fmt.Sprintf("%s %s  %s/s", b.description, formatBytes(b.written), formatBytes(rate))
 	}
 
 	if b.isTerm {
-		fmt.Fprint(b.out, "\r\033[K"+line) //nolint:errcheck // Why: Best effort
+		fmt.Fprint(b.out, term.ClearLine, line) //nolint:errcheck // Why: Best effort
 	} else {
 		fmt.Fprintln(b.out, line) //nolint:errcheck // Why: Best effort
 	}

--- a/pkg/cli/progress/progress.go
+++ b/pkg/cli/progress/progress.go
@@ -50,6 +50,7 @@ type Bytes struct {
 	bar         barprogress.Model
 	out         io.Writer
 	now         func() time.Time
+	termWidth   func() (width int, ok bool)
 
 	written  int64
 	start    time.Time
@@ -61,13 +62,16 @@ type Bytes struct {
 // (pass <= 0 if the size isn't known ahead of time), labeled with
 // description.
 func NewBytes(total int64, description string) *Bytes {
-	return newBytes(total, description, os.Stderr, term.IsTerminal(os.Stderr), time.Now)
+	termWidth := func() (int, bool) { return term.Width(os.Stderr) }
+	return newBytes(total, description, os.Stderr, term.IsTerminal(os.Stderr), time.Now, termWidth)
 }
 
-// newBytes builds a Bytes with explicit out/isTerm/now, so tests can
-// substitute a buffer and a controllable clock without going through
-// NewBytes' os.Stderr/time.Now defaults.
-func newBytes(total int64, description string, out io.Writer, isTerm bool, now func() time.Time) *Bytes {
+// newBytes builds a Bytes with explicit out/isTerm/now/termWidth, so
+// tests can substitute a buffer, a controllable clock, and a fixed
+// terminal width without going through NewBytes' os.Stderr defaults.
+func newBytes(
+	total int64, description string, out io.Writer, isTerm bool, now func() time.Time, termWidth func() (int, bool),
+) *Bytes {
 	b := &Bytes{
 		description: description,
 		total:       total,
@@ -76,6 +80,7 @@ func newBytes(total int64, description string, out io.Writer, isTerm bool, now f
 		bar:         barprogress.New(barprogress.WithDefaultBlend()),
 		out:         out,
 		now:         now,
+		termWidth:   termWidth,
 	}
 	b.start = b.now()
 	return b
@@ -127,9 +132,18 @@ func (b *Bytes) draw(force bool) {
 	case b.total > 0 && b.isTerm:
 		// The styled bar is only worth rendering when it'll actually be
 		// shown; skip it in the plain, non-terminal case below.
+		suffix := fmt.Sprintf("  %s/%s  %s/s", formatBytes(b.written), b.totalStr, formatBytes(rate))
+
+		// Re-check the terminal width on every redraw (not just once at
+		// construction) and size the bar to fill the remaining space, so
+		// the line keeps fitting the terminal across resizes the same
+		// way github.com/schollz/progressbar's OptionFullWidth did.
+		if width, ok := b.termWidth(); ok {
+			b.bar.SetWidth(width - len(b.description) - 1 - len(suffix))
+		}
+
 		percent := min(1, float64(b.written)/float64(b.total))
-		line = fmt.Sprintf("%s %s  %s/%s  %s/s",
-			b.description, b.bar.ViewAs(percent), formatBytes(b.written), b.totalStr, formatBytes(rate))
+		line = b.description + " " + b.bar.ViewAs(percent) + suffix
 	case b.total > 0:
 		line = fmt.Sprintf("%s %s/%s  %s/s", b.description, formatBytes(b.written), b.totalStr, formatBytes(rate))
 	default:

--- a/pkg/cli/progress/progress.go
+++ b/pkg/cli/progress/progress.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+// Description: Implements a byte-progress meter for long running
+// transfers, e.g. downloads and archive extraction, built on Bubble Tea's
+// progress bar component.
+
+// Package progress implements a small byte-progress meter on top of
+// charm.land/bubbles/v2/progress, for use in place of
+// github.com/schollz/progressbar/v3.
+package progress
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	barprogress "charm.land/bubbles/v2/progress"
+	"golang.org/x/term"
+)
+
+const (
+	// redrawInterval throttles how often an interactive progress bar is
+	// redrawn, so Write doesn't flood the terminal with escape codes.
+	redrawInterval = 65 * time.Millisecond
+
+	// plainInterval throttles how often a status line is printed when
+	// stderr isn't a terminal, so redirected or logged output doesn't get
+	// a line per Write call.
+	plainInterval = time.Second
+)
+
+// Bytes is an io.WriteCloser that renders a labeled progress bar to
+// os.Stderr as bytes are written through it. Wrap it around a transfer with
+// io.MultiWriter (for an io.Writer destination) or io.TeeReader (for an
+// io.Reader source).
+//
+// If total is <= 0 (e.g. the size wasn't known ahead of time), Bytes falls
+// back to reporting only the count of bytes transferred, since a
+// percentage can't be computed.
+//
+// If os.Stderr isn't a terminal, Bytes prints an occasional plain text
+// status line instead of redrawing a bar in place, so piped or logged
+// output isn't filled with redraw escape codes.
+type Bytes struct {
+	description string
+	total       int64
+	isTerm      bool
+	bar         barprogress.Model
+	out         io.Writer
+	now         func() time.Time
+
+	written  int64
+	start    time.Time
+	lastDraw time.Time
+	closed   bool
+}
+
+// NewBytes returns a Bytes progress meter for a transfer of total bytes
+// (pass <= 0 if the size isn't known ahead of time), labeled with
+// description.
+func NewBytes(total int64, description string) *Bytes {
+	b := &Bytes{
+		description: description,
+		total:       total,
+		isTerm:      term.IsTerminal(int(os.Stderr.Fd())),
+		bar:         barprogress.New(barprogress.WithDefaultBlend()),
+		out:         os.Stderr,
+		now:         time.Now,
+	}
+	b.start = b.now()
+	return b
+}
+
+// Write implements io.Writer, recording len(p) bytes as transferred and
+// redrawing the progress bar if enough time has passed since the last
+// redraw. It never returns an error.
+func (b *Bytes) Write(p []byte) (int, error) {
+	b.written += int64(len(p))
+	b.draw(false)
+	return len(p), nil
+}
+
+// Close redraws the progress bar a final time to reflect the final byte
+// count and prints a trailing newline. It's safe to call multiple times.
+func (b *Bytes) Close() error {
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+
+	b.draw(true)
+	fmt.Fprintln(b.out) //nolint:errcheck // Why: Best effort
+	return nil
+}
+
+// draw redraws the current progress, subject to throttling, unless force
+// is set.
+func (b *Bytes) draw(force bool) {
+	interval := redrawInterval
+	if !b.isTerm {
+		interval = plainInterval
+	}
+
+	now := b.now()
+	if !force && now.Sub(b.lastDraw) < interval {
+		return
+	}
+	b.lastDraw = now
+
+	rate := int64(0)
+	if elapsed := now.Sub(b.start).Seconds(); elapsed > 0 {
+		rate = int64(float64(b.written) / elapsed)
+	}
+
+	line := fmt.Sprintf("%s %s  %s/s", b.description, formatBytes(b.written), formatBytes(rate))
+	if b.total > 0 {
+		percent := min(1, float64(b.written)/float64(b.total))
+		line = fmt.Sprintf("%s %s  %s/%s  %s/s",
+			b.description, b.bar.ViewAs(percent), formatBytes(b.written), formatBytes(b.total), formatBytes(rate))
+	}
+
+	if b.isTerm {
+		fmt.Fprint(b.out, "\r\033[K"+line) //nolint:errcheck // Why: Best effort
+	} else {
+		fmt.Fprintln(b.out, line) //nolint:errcheck // Why: Best effort
+	}
+}
+
+// formatBytes renders n bytes as a human-readable string using binary
+// (1024-based) units, e.g. "1.5 MiB".
+func formatBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+
+	div, exp := int64(unit), 0
+	for m := n / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/pkg/cli/progress/progress_test.go
+++ b/pkg/cli/progress/progress_test.go
@@ -46,12 +46,7 @@ func fakeClock(step time.Duration) func() time.Time {
 
 func newTestBytes(total int64, isTerm bool, now func() time.Time) (*Bytes, *bytes.Buffer) {
 	var buf bytes.Buffer
-	b := NewBytes(total, "test")
-	b.isTerm = isTerm
-	b.out = &buf
-	b.now = now
-	b.start = b.now()
-	return b, &buf
+	return newBytes(total, "test", &buf, isTerm, now), &buf
 }
 
 func TestBytesWriteThrottlesRedraws(t *testing.T) {

--- a/pkg/cli/progress/progress_test.go
+++ b/pkg/cli/progress/progress_test.go
@@ -49,35 +49,52 @@ func fakeClock(step time.Duration) func() time.Time {
 // matching what term.Width returns for a non-terminal file.
 func unknownWidth() (int, bool) { return 0, false }
 
-func newTestBytes(total int64, isTerm bool, now func() time.Time) (*Bytes, *bytes.Buffer) {
+// newTestBytes returns a Bytes wired to a buffer, for tests that don't
+// need to control the reported terminal width.
+func newTestBytes(t *testing.T, total int64, isTerm bool, now func() time.Time) (*Bytes, *bytes.Buffer) {
+	t.Helper()
+
 	var buf bytes.Buffer
 	return newBytes(total, "test", &buf, isTerm, now, unknownWidth), &buf
+}
+
+// mustWrite writes p to w, failing the test immediately if it errors.
+func mustWrite(t *testing.T, w io.Writer, p []byte) {
+	t.Helper()
+
+	_, err := w.Write(p)
+	assert.NilError(t, err)
+}
+
+// mustClose closes c, failing the test immediately if it errors.
+func mustClose(t *testing.T, c io.Closer) {
+	t.Helper()
+
+	assert.NilError(t, c.Close())
 }
 
 func TestBytesWriteThrottlesRedraws(t *testing.T) {
 	// Each call to now() advances by 1ms, well under redrawInterval, so
 	// only the first Write (which always draws, since lastDraw is zero)
 	// should produce output.
-	b, buf := newTestBytes(100, true, fakeClock(time.Millisecond))
+	b, buf := newTestBytes(t, 100, true, fakeClock(time.Millisecond))
 
 	for range 5 {
-		_, err := b.Write([]byte("x"))
-		assert.NilError(t, err)
+		mustWrite(t, b, []byte("x"))
 	}
 
 	assert.Equal(t, strings.Count(buf.String(), "\r"), 1)
 }
 
 func TestBytesCloseIsIdempotent(t *testing.T) {
-	b, buf := newTestBytes(100, true, fakeClock(time.Millisecond))
+	b, buf := newTestBytes(t, 100, true, fakeClock(time.Millisecond))
 
-	_, err := b.Write([]byte(strings.Repeat("x", 100)))
-	assert.NilError(t, err)
+	mustWrite(t, b, []byte(strings.Repeat("x", 100)))
 
-	assert.NilError(t, b.Close())
+	mustClose(t, b)
 	afterFirstClose := buf.String()
 
-	assert.NilError(t, b.Close())
+	mustClose(t, b)
 
 	assert.Equal(t, buf.String(), afterFirstClose)
 	assert.Assert(t, strings.HasSuffix(afterFirstClose, "\n"),
@@ -87,20 +104,18 @@ func TestBytesCloseIsIdempotent(t *testing.T) {
 func TestBytesUnknownTotal(t *testing.T) {
 	// total <= 0 means no percentage can be computed; the rendered line
 	// should still report the transferred count, without a bar.
-	b, buf := newTestBytes(0, false, fakeClock(2*time.Second))
+	b, buf := newTestBytes(t, 0, false, fakeClock(2*time.Second))
 
-	_, err := b.Write([]byte(strings.Repeat("x", 2048)))
-	assert.NilError(t, err)
+	mustWrite(t, b, []byte(strings.Repeat("x", 2048)))
 
 	assert.Assert(t, cmp.Contains(buf.String(), "test"))
 	assert.Assert(t, cmp.Contains(buf.String(), "2.0 KiB"))
 }
 
 func TestBytesNonTerminalUsesPlainLines(t *testing.T) {
-	b, buf := newTestBytes(100, false, fakeClock(2*time.Second))
+	b, buf := newTestBytes(t, 100, false, fakeClock(2*time.Second))
 
-	_, err := b.Write([]byte(strings.Repeat("x", 50)))
-	assert.NilError(t, err)
+	mustWrite(t, b, []byte(strings.Repeat("x", 50)))
 
 	assert.Assert(t, !strings.Contains(buf.String(), "\r"),
 		"non-terminal output should not contain carriage returns: %q", buf.String())
@@ -111,10 +126,9 @@ func TestBytesNonTerminalUsesPlainLines(t *testing.T) {
 func TestBytesKeepsDefaultBarWidthWhenTerminalWidthUnknown(t *testing.T) {
 	const defaultBarWidth = 40 // charm.land/bubbles/v2/progress's unexported defaultWidth
 
-	b, _ := newTestBytes(100, true, fakeClock(time.Millisecond))
+	b, _ := newTestBytes(t, 100, true, fakeClock(time.Millisecond))
 
-	_, err := b.Write([]byte("x"))
-	assert.NilError(t, err)
+	mustWrite(t, b, []byte("x"))
 
 	assert.Equal(t, b.bar.Width(), defaultBarWidth)
 }
@@ -126,8 +140,7 @@ func TestBytesResizesBarToTerminalWidth(t *testing.T) {
 	narrow := func() (int, bool) { return 20, true }
 	b := newBytes(100, "dl", &buf, true, fakeClock(time.Millisecond), narrow)
 
-	_, err := b.Write([]byte(strings.Repeat("x", 10)))
-	assert.NilError(t, err)
+	mustWrite(t, b, []byte(strings.Repeat("x", 10)))
 
 	// A 20-column terminal can't fit "dl" plus a 40-char bar plus the
 	// byte-count/rate suffix; the bar must shrink to fit, the way

--- a/pkg/cli/progress/progress_test.go
+++ b/pkg/cli/progress/progress_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+package progress
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int64
+		want string
+	}{
+		{name: "zero", n: 0, want: "0 B"},
+		{name: "under a KiB", n: 512, want: "512 B"},
+		{name: "exactly a KiB", n: 1024, want: "1.0 KiB"},
+		{name: "fractional MiB", n: 1024*1024*3 + 1024*512, want: "3.5 MiB"},
+		{name: "GiB", n: 1024 * 1024 * 1024 * 2, want: "2.0 GiB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatBytes(tt.n); got != tt.want {
+				t.Errorf("formatBytes(%d) = %q, want %q", tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+// fakeClock returns a stepped time.Time on each call, advancing by step
+// every time now() is invoked, so tests can control elapsed time
+// deterministically.
+func fakeClock(step time.Duration) func() time.Time {
+	cur := time.Unix(0, 0)
+	return func() time.Time {
+		t := cur
+		cur = cur.Add(step)
+		return t
+	}
+}
+
+func newTestBytes(total int64, isTerm bool, now func() time.Time) (*Bytes, *bytes.Buffer) {
+	var buf bytes.Buffer
+	b := NewBytes(total, "test")
+	b.isTerm = isTerm
+	b.out = &buf
+	b.now = now
+	b.start = b.now()
+	return b, &buf
+}
+
+func TestBytesWriteThrottlesRedraws(t *testing.T) {
+	// Each call to now() advances by 1ms, well under redrawInterval, so
+	// only the first Write (which always draws, since lastDraw is zero)
+	// should produce output.
+	b, buf := newTestBytes(100, true, fakeClock(time.Millisecond))
+
+	for range 5 {
+		if _, err := b.Write([]byte("x")); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	if n := strings.Count(buf.String(), "\r"); n != 1 {
+		t.Errorf("got %d redraws, want 1 (throttled)", n)
+	}
+}
+
+func TestBytesCloseIsIdempotent(t *testing.T) {
+	b, buf := newTestBytes(100, true, fakeClock(time.Millisecond))
+
+	if _, err := b.Write([]byte(strings.Repeat("x", 100))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	afterFirstClose := buf.String()
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+
+	if buf.String() != afterFirstClose {
+		t.Errorf("second Close produced more output: got %q, want %q", buf.String(), afterFirstClose)
+	}
+	if !strings.HasSuffix(afterFirstClose, "\n") {
+		t.Errorf("Close output %q does not end with a trailing newline", afterFirstClose)
+	}
+}
+
+func TestBytesUnknownTotal(t *testing.T) {
+	// total <= 0 means no percentage can be computed; the rendered line
+	// should still report the transferred count, without a bar.
+	b, buf := newTestBytes(0, false, fakeClock(2*time.Second))
+
+	if _, err := b.Write([]byte(strings.Repeat("x", 2048))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if got := buf.String(); !strings.Contains(got, "test") || !strings.Contains(got, "2.0 KiB") {
+		t.Errorf("unexpected output for unknown total: %q", got)
+	}
+}
+
+func TestBytesNonTerminalUsesPlainLines(t *testing.T) {
+	b, buf := newTestBytes(100, false, fakeClock(2*time.Second))
+
+	if _, err := b.Write([]byte(strings.Repeat("x", 50))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "\r") {
+		t.Errorf("non-terminal output should not contain carriage returns: %q", buf.String())
+	}
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Errorf("non-terminal output should be newline-terminated: %q", buf.String())
+	}
+}
+
+var _ io.WriteCloser = (*Bytes)(nil)

--- a/pkg/cli/progress/progress_test.go
+++ b/pkg/cli/progress/progress_test.go
@@ -44,9 +44,13 @@ func fakeClock(step time.Duration) func() time.Time {
 	}
 }
 
+// unknownWidth reports that the terminal width can't be determined,
+// matching what term.Width returns for a non-terminal file.
+func unknownWidth() (int, bool) { return 0, false }
+
 func newTestBytes(total int64, isTerm bool, now func() time.Time) (*Bytes, *bytes.Buffer) {
 	var buf bytes.Buffer
-	return newBytes(total, "test", &buf, isTerm, now), &buf
+	return newBytes(total, "test", &buf, isTerm, now, unknownWidth), &buf
 }
 
 func TestBytesWriteThrottlesRedraws(t *testing.T) {
@@ -116,6 +120,39 @@ func TestBytesNonTerminalUsesPlainLines(t *testing.T) {
 	}
 	if !strings.HasSuffix(buf.String(), "\n") {
 		t.Errorf("non-terminal output should be newline-terminated: %q", buf.String())
+	}
+}
+
+func TestBytesKeepsDefaultBarWidthWhenTerminalWidthUnknown(t *testing.T) {
+	const defaultBarWidth = 40 // charm.land/bubbles/v2/progress's unexported defaultWidth
+
+	b, _ := newTestBytes(100, true, fakeClock(time.Millisecond))
+
+	if _, err := b.Write([]byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if got := b.bar.Width(); got != defaultBarWidth {
+		t.Errorf("bar width = %d, want unchanged default %d when terminal width can't be determined", got, defaultBarWidth)
+	}
+}
+
+func TestBytesResizesBarToTerminalWidth(t *testing.T) {
+	const defaultBarWidth = 40 // charm.land/bubbles/v2/progress's unexported defaultWidth
+
+	var buf bytes.Buffer
+	narrow := func() (int, bool) { return 20, true }
+	b := newBytes(100, "dl", &buf, true, fakeClock(time.Millisecond), narrow)
+
+	if _, err := b.Write([]byte(strings.Repeat("x", 10))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// A 20-column terminal can't fit "dl" plus a 40-char bar plus the
+	// byte-count/rate suffix; the bar must shrink to fit, the way
+	// schollz/progressbar's OptionFullWidth did across resizes.
+	if got := b.bar.Width(); got >= defaultBarWidth {
+		t.Errorf("bar width = %d, want it shrunk below the unfitted default (%d) for a 20-column terminal", got, defaultBarWidth)
 	}
 }
 

--- a/pkg/cli/progress/progress_test.go
+++ b/pkg/cli/progress/progress_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
 func TestFormatBytes(t *testing.T) {
@@ -25,9 +28,7 @@ func TestFormatBytes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := formatBytes(tt.n); got != tt.want {
-				t.Errorf("formatBytes(%d) = %q, want %q", tt.n, got, tt.want)
-			}
+			assert.Equal(t, formatBytes(tt.n), tt.want)
 		})
 	}
 }
@@ -60,38 +61,27 @@ func TestBytesWriteThrottlesRedraws(t *testing.T) {
 	b, buf := newTestBytes(100, true, fakeClock(time.Millisecond))
 
 	for range 5 {
-		if _, err := b.Write([]byte("x")); err != nil {
-			t.Fatalf("Write: %v", err)
-		}
+		_, err := b.Write([]byte("x"))
+		assert.NilError(t, err)
 	}
 
-	if n := strings.Count(buf.String(), "\r"); n != 1 {
-		t.Errorf("got %d redraws, want 1 (throttled)", n)
-	}
+	assert.Equal(t, strings.Count(buf.String(), "\r"), 1)
 }
 
 func TestBytesCloseIsIdempotent(t *testing.T) {
 	b, buf := newTestBytes(100, true, fakeClock(time.Millisecond))
 
-	if _, err := b.Write([]byte(strings.Repeat("x", 100))); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	_, err := b.Write([]byte(strings.Repeat("x", 100)))
+	assert.NilError(t, err)
 
-	if err := b.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
+	assert.NilError(t, b.Close())
 	afterFirstClose := buf.String()
 
-	if err := b.Close(); err != nil {
-		t.Fatalf("second Close: %v", err)
-	}
+	assert.NilError(t, b.Close())
 
-	if buf.String() != afterFirstClose {
-		t.Errorf("second Close produced more output: got %q, want %q", buf.String(), afterFirstClose)
-	}
-	if !strings.HasSuffix(afterFirstClose, "\n") {
-		t.Errorf("Close output %q does not end with a trailing newline", afterFirstClose)
-	}
+	assert.Equal(t, buf.String(), afterFirstClose)
+	assert.Assert(t, strings.HasSuffix(afterFirstClose, "\n"),
+		"Close output %q does not end with a trailing newline", afterFirstClose)
 }
 
 func TestBytesUnknownTotal(t *testing.T) {
@@ -99,28 +89,23 @@ func TestBytesUnknownTotal(t *testing.T) {
 	// should still report the transferred count, without a bar.
 	b, buf := newTestBytes(0, false, fakeClock(2*time.Second))
 
-	if _, err := b.Write([]byte(strings.Repeat("x", 2048))); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	_, err := b.Write([]byte(strings.Repeat("x", 2048)))
+	assert.NilError(t, err)
 
-	if got := buf.String(); !strings.Contains(got, "test") || !strings.Contains(got, "2.0 KiB") {
-		t.Errorf("unexpected output for unknown total: %q", got)
-	}
+	assert.Assert(t, cmp.Contains(buf.String(), "test"))
+	assert.Assert(t, cmp.Contains(buf.String(), "2.0 KiB"))
 }
 
 func TestBytesNonTerminalUsesPlainLines(t *testing.T) {
 	b, buf := newTestBytes(100, false, fakeClock(2*time.Second))
 
-	if _, err := b.Write([]byte(strings.Repeat("x", 50))); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	_, err := b.Write([]byte(strings.Repeat("x", 50)))
+	assert.NilError(t, err)
 
-	if strings.Contains(buf.String(), "\r") {
-		t.Errorf("non-terminal output should not contain carriage returns: %q", buf.String())
-	}
-	if !strings.HasSuffix(buf.String(), "\n") {
-		t.Errorf("non-terminal output should be newline-terminated: %q", buf.String())
-	}
+	assert.Assert(t, !strings.Contains(buf.String(), "\r"),
+		"non-terminal output should not contain carriage returns: %q", buf.String())
+	assert.Assert(t, strings.HasSuffix(buf.String(), "\n"),
+		"non-terminal output should be newline-terminated: %q", buf.String())
 }
 
 func TestBytesKeepsDefaultBarWidthWhenTerminalWidthUnknown(t *testing.T) {
@@ -128,13 +113,10 @@ func TestBytesKeepsDefaultBarWidthWhenTerminalWidthUnknown(t *testing.T) {
 
 	b, _ := newTestBytes(100, true, fakeClock(time.Millisecond))
 
-	if _, err := b.Write([]byte("x")); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	_, err := b.Write([]byte("x"))
+	assert.NilError(t, err)
 
-	if got := b.bar.Width(); got != defaultBarWidth {
-		t.Errorf("bar width = %d, want unchanged default %d when terminal width can't be determined", got, defaultBarWidth)
-	}
+	assert.Equal(t, b.bar.Width(), defaultBarWidth)
 }
 
 func TestBytesResizesBarToTerminalWidth(t *testing.T) {
@@ -144,16 +126,14 @@ func TestBytesResizesBarToTerminalWidth(t *testing.T) {
 	narrow := func() (int, bool) { return 20, true }
 	b := newBytes(100, "dl", &buf, true, fakeClock(time.Millisecond), narrow)
 
-	if _, err := b.Write([]byte(strings.Repeat("x", 10))); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
+	_, err := b.Write([]byte(strings.Repeat("x", 10)))
+	assert.NilError(t, err)
 
 	// A 20-column terminal can't fit "dl" plus a 40-char bar plus the
 	// byte-count/rate suffix; the bar must shrink to fit, the way
 	// schollz/progressbar's OptionFullWidth did across resizes.
-	if got := b.bar.Width(); got >= defaultBarWidth {
-		t.Errorf("bar width = %d, want it shrunk below the unfitted default (%d) for a 20-column terminal", got, defaultBarWidth)
-	}
+	assert.Assert(t, b.bar.Width() < defaultBarWidth,
+		"bar width = %d, want it shrunk below the unfitted default (%d) for a 20-column terminal", b.bar.Width(), defaultBarWidth)
 }
 
 var _ io.WriteCloser = (*Bytes)(nil)

--- a/pkg/cli/spinner/spinner.go
+++ b/pkg/cli/spinner/spinner.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+// Description: Implements a simple animated spinner for indicating
+// progress during a blocking operation, built on Bubble Tea's spinner
+// component.
+
+// Package spinner implements a small animated spinner on top of
+// charm.land/bubbles/v2/spinner, for use in place of
+// github.com/briandowns/spinner.
+package spinner
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	barspinner "charm.land/bubbles/v2/spinner"
+	"golang.org/x/term"
+)
+
+// Spinner animates a labeled spinner on os.Stderr while a blocking
+// operation runs elsewhere. Call Start to begin animating, then Stop once
+// the operation finishes; Stop clears the spinner's line.
+//
+// If os.Stderr isn't a terminal, Start instead prints the description once
+// as a plain line, since an animated spinner would be meaningless in
+// redirected or logged output; Stop is then a no-op.
+type Spinner struct {
+	description string
+	model       barspinner.Model
+	isTerm      bool
+	out         io.Writer
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// New returns a Spinner labeled with description, using the same frames
+// and cadence as github.com/briandowns/spinner's CharSets[9].
+func New(description string) *Spinner {
+	return &Spinner{
+		description: description,
+		model:       barspinner.New(barspinner.WithSpinner(barspinner.Line)),
+		isTerm:      term.IsTerminal(int(os.Stderr.Fd())),
+		out:         os.Stderr,
+	}
+}
+
+// Start begins animating the spinner in a background goroutine. It's a
+// no-op if the spinner is already running.
+func (s *Spinner) Start() {
+	if !s.isTerm {
+		fmt.Fprintln(s.out, s.description) //nolint:errcheck // Why: Best effort
+		return
+	}
+
+	if s.stop != nil {
+		return
+	}
+
+	s.stop = make(chan struct{})
+	s.done = make(chan struct{})
+	go s.run()
+}
+
+// Stop halts the animation and clears the spinner's line. It's safe to
+// call even if Start hasn't been called, or has already been stopped.
+func (s *Spinner) Stop() {
+	if s.stop == nil {
+		return
+	}
+
+	close(s.stop)
+	<-s.done
+	s.stop = nil
+}
+
+// run redraws the spinner on its own ticker, matching the frame rate of
+// the underlying Bubble Tea spinner model, until Stop closes s.stop.
+func (s *Spinner) run() {
+	defer close(s.done)
+
+	ticker := time.NewTicker(s.model.Spinner.FPS)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.stop:
+			fmt.Fprint(s.out, "\r\033[K") //nolint:errcheck // Why: Best effort
+			return
+		case <-ticker.C:
+			s.model, _ = s.model.Update(s.model.Tick())
+			fmt.Fprintf(s.out, "\r\033[K%s %s", s.model.View(), s.description) //nolint:errcheck // Why: Best effort
+		}
+	}
+}

--- a/pkg/cli/spinner/spinner.go
+++ b/pkg/cli/spinner/spinner.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	barspinner "charm.land/bubbles/v2/spinner"
-	"golang.org/x/term"
+	"github.com/getoutreach/gobox/pkg/cli/internal/term"
 )
 
 // Spinner animates a labeled spinner on os.Stderr while a blocking
@@ -42,7 +42,7 @@ func New(description string) *Spinner {
 	return &Spinner{
 		description: description,
 		model:       barspinner.New(barspinner.WithSpinner(barspinner.Line)),
-		isTerm:      term.IsTerminal(int(os.Stderr.Fd())),
+		isTerm:      term.IsTerminal(os.Stderr),
 		out:         os.Stderr,
 	}
 }
@@ -87,11 +87,11 @@ func (s *Spinner) run() {
 	for {
 		select {
 		case <-s.stop:
-			fmt.Fprint(s.out, "\r\033[K") //nolint:errcheck // Why: Best effort
+			fmt.Fprint(s.out, term.ClearLine) //nolint:errcheck // Why: Best effort
 			return
 		case <-ticker.C:
 			s.model, _ = s.model.Update(s.model.Tick())
-			fmt.Fprintf(s.out, "\r\033[K%s %s", s.model.View(), s.description) //nolint:errcheck // Why: Best effort
+			fmt.Fprint(s.out, term.ClearLine, s.model.View(), " ", s.description) //nolint:errcheck // Why: Best effort
 		}
 	}
 }

--- a/pkg/cli/spinner/spinner_test.go
+++ b/pkg/cli/spinner/spinner_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+package spinner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSpinnerNonTerminalPrintsDescriptionOnce(t *testing.T) {
+	var buf bytes.Buffer
+	s := New("Checking for updates...")
+	s.out = &buf
+	s.isTerm = false
+
+	s.Start()
+	s.Stop()
+
+	if got := buf.String(); got != "Checking for updates...\n" {
+		t.Errorf("got %q, want a single description line", got)
+	}
+}
+
+func TestSpinnerStopWithoutStartIsSafe(t *testing.T) {
+	s := New("test")
+	s.Stop() // must not block or panic
+}
+
+func TestSpinnerTerminalAnimatesAndClearsOnStop(t *testing.T) {
+	var buf bytes.Buffer
+	s := New("Checking for updates...")
+	s.out = &buf
+	s.isTerm = true
+	s.model.Spinner.FPS = time.Millisecond
+
+	s.Start()
+	time.Sleep(10 * time.Millisecond) // let a few frames render
+	s.Stop()
+
+	got := buf.String()
+	if !strings.Contains(got, "Checking for updates...") {
+		t.Errorf("output %q does not contain the description", got)
+	}
+	if !strings.HasSuffix(got, "\r\033[K") {
+		t.Errorf("output %q does not end with the line-clear sequence", got)
+	}
+}
+
+func TestSpinnerDoubleStopIsSafe(t *testing.T) {
+	var buf bytes.Buffer
+	s := New("test")
+	s.out = &buf
+	s.isTerm = true
+	s.model.Spinner.FPS = time.Millisecond
+
+	s.Start()
+	s.Stop()
+	s.Stop() // must not block or panic
+}
+
+func TestSpinnerDoubleStartIsSafe(t *testing.T) {
+	var buf bytes.Buffer
+	s := New("test")
+	s.out = &buf
+	s.isTerm = true
+	s.model.Spinner.FPS = time.Millisecond
+
+	s.Start()
+	s.Start() // must not spawn a second goroutine or panic
+	s.Stop()
+}

--- a/pkg/cli/spinner/spinner_test.go
+++ b/pkg/cli/spinner/spinner_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
 func TestSpinnerNonTerminalPrintsDescriptionOnce(t *testing.T) {
@@ -18,9 +21,7 @@ func TestSpinnerNonTerminalPrintsDescriptionOnce(t *testing.T) {
 	s.Start()
 	s.Stop()
 
-	if got := buf.String(); got != "Checking for updates...\n" {
-		t.Errorf("got %q, want a single description line", got)
-	}
+	assert.Equal(t, buf.String(), "Checking for updates...\n")
 }
 
 func TestSpinnerStopWithoutStartIsSafe(t *testing.T) {
@@ -30,7 +31,9 @@ func TestSpinnerStopWithoutStartIsSafe(t *testing.T) {
 
 // newTestSpinner returns a Spinner wired to a buffer with a fast frame
 // rate, so animation tests don't need to wait for a real spinner cadence.
-func newTestSpinner(description string) (*Spinner, *bytes.Buffer) {
+func newTestSpinner(t *testing.T, description string) (*Spinner, *bytes.Buffer) {
+	t.Helper()
+
 	var buf bytes.Buffer
 	s := New(description)
 	s.out = &buf
@@ -40,23 +43,20 @@ func newTestSpinner(description string) (*Spinner, *bytes.Buffer) {
 }
 
 func TestSpinnerTerminalAnimatesAndClearsOnStop(t *testing.T) {
-	s, buf := newTestSpinner("Checking for updates...")
+	s, buf := newTestSpinner(t, "Checking for updates...")
 
 	s.Start()
 	time.Sleep(10 * time.Millisecond) // let a few frames render
 	s.Stop()
 
 	got := buf.String()
-	if !strings.Contains(got, "Checking for updates...") {
-		t.Errorf("output %q does not contain the description", got)
-	}
-	if !strings.HasSuffix(got, "\r\033[K") {
-		t.Errorf("output %q does not end with the line-clear sequence", got)
-	}
+	assert.Assert(t, cmp.Contains(got, "Checking for updates..."))
+	assert.Assert(t, strings.HasSuffix(got, "\r\033[K"),
+		"output %q does not end with the line-clear sequence", got)
 }
 
 func TestSpinnerDoubleStopIsSafe(t *testing.T) {
-	s, _ := newTestSpinner("test")
+	s, _ := newTestSpinner(t, "test")
 
 	s.Start()
 	s.Stop()
@@ -64,7 +64,7 @@ func TestSpinnerDoubleStopIsSafe(t *testing.T) {
 }
 
 func TestSpinnerDoubleStartIsSafe(t *testing.T) {
-	s, _ := newTestSpinner("test")
+	s, _ := newTestSpinner(t, "test")
 
 	s.Start()
 	s.Start() // must not spawn a second goroutine or panic

--- a/pkg/cli/spinner/spinner_test.go
+++ b/pkg/cli/spinner/spinner_test.go
@@ -28,12 +28,19 @@ func TestSpinnerStopWithoutStartIsSafe(t *testing.T) {
 	s.Stop() // must not block or panic
 }
 
-func TestSpinnerTerminalAnimatesAndClearsOnStop(t *testing.T) {
+// newTestSpinner returns a Spinner wired to a buffer with a fast frame
+// rate, so animation tests don't need to wait for a real spinner cadence.
+func newTestSpinner(description string) (*Spinner, *bytes.Buffer) {
 	var buf bytes.Buffer
-	s := New("Checking for updates...")
+	s := New(description)
 	s.out = &buf
 	s.isTerm = true
 	s.model.Spinner.FPS = time.Millisecond
+	return s, &buf
+}
+
+func TestSpinnerTerminalAnimatesAndClearsOnStop(t *testing.T) {
+	s, buf := newTestSpinner("Checking for updates...")
 
 	s.Start()
 	time.Sleep(10 * time.Millisecond) // let a few frames render
@@ -49,11 +56,7 @@ func TestSpinnerTerminalAnimatesAndClearsOnStop(t *testing.T) {
 }
 
 func TestSpinnerDoubleStopIsSafe(t *testing.T) {
-	var buf bytes.Buffer
-	s := New("test")
-	s.out = &buf
-	s.isTerm = true
-	s.model.Spinner.FPS = time.Millisecond
+	s, _ := newTestSpinner("test")
 
 	s.Start()
 	s.Stop()
@@ -61,11 +64,7 @@ func TestSpinnerDoubleStopIsSafe(t *testing.T) {
 }
 
 func TestSpinnerDoubleStartIsSafe(t *testing.T) {
-	var buf bytes.Buffer
-	s := New("test")
-	s.out = &buf
-	s.isTerm = true
-	s.model.Spinner.FPS = time.Millisecond
+	s, _ := newTestSpinner("test")
 
 	s.Start()
 	s.Start() // must not spawn a second goroutine or panic

--- a/pkg/cli/updater/updater.go
+++ b/pkg/cli/updater/updater.go
@@ -21,6 +21,7 @@ import (
 	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/gobox/pkg/cfg"
 	"github.com/getoutreach/gobox/pkg/cli/github"
+	"github.com/getoutreach/gobox/pkg/cli/internal/term"
 	"github.com/getoutreach/gobox/pkg/cli/progress"
 	"github.com/getoutreach/gobox/pkg/cli/spinner"
 	"github.com/getoutreach/gobox/pkg/cli/updater/archive"
@@ -31,7 +32,6 @@ import (
 	"github.com/sirupsen/logrus"
 	cliV2 "github.com/urfave/cli/v2"
 	cliV3 "github.com/urfave/cli/v3"
-	"golang.org/x/term"
 )
 
 // Disabled globally disables the automatic updater.
@@ -281,7 +281,7 @@ func (u *updater) getVersionInfo(v *semver.Version) (channel string, locallyBuil
 func (u *updater) check(ctx context.Context) (bool, error) {
 	// Never update when device is not a terminal, or when in a CI environment. However,
 	// we allow forceCheck to override this.
-	if u.disabled || (!u.forceCheck && (!term.IsTerminal(int(os.Stdin.Fd())) || os.Getenv("CI") != "")) {
+	if u.disabled || (!u.forceCheck && (!term.IsTerminal(os.Stdin) || os.Getenv("CI") != "")) {
 		return false, nil
 	}
 

--- a/pkg/cli/updater/updater.go
+++ b/pkg/cli/updater/updater.go
@@ -22,12 +22,12 @@ import (
 	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/gobox/pkg/cfg"
 	"github.com/getoutreach/gobox/pkg/cli/github"
+	"github.com/getoutreach/gobox/pkg/cli/progress"
 	"github.com/getoutreach/gobox/pkg/cli/updater/archive"
 	"github.com/getoutreach/gobox/pkg/cli/updater/release"
 	"github.com/getoutreach/gobox/pkg/cli/updater/resolver"
 	"github.com/getoutreach/gobox/pkg/exec"
 	"github.com/pkg/errors"
-	"github.com/schollz/progressbar/v3"
 	"github.com/sirupsen/logrus"
 	cliV2 "github.com/urfave/cli/v2"
 	cliV3 "github.com/urfave/cli/v3"
@@ -424,7 +424,7 @@ func (u *updater) installVersion(ctx context.Context, v *resolver.Version) error
 
 	var w io.Writer = tmpF
 	if !u.noProgressBar {
-		pb := progressbar.DefaultBytes(aSize, "Downloading Update")
+		pb := progress.NewBytes(aSize, "Downloading Update")
 		defer pb.Close()
 
 		w = io.MultiWriter(tmpF, pb)
@@ -461,7 +461,7 @@ func (u *updater) installVersion(ctx context.Context, v *resolver.Version) error
 	var r io.Reader = bin
 	if !u.noProgressBar {
 		// There's an empty space here to make it align with the first progress bar.
-		pb := progressbar.DefaultBytes(header.Size, "Extracting Update ")
+		pb := progress.NewBytes(header.Size, "Extracting Update ")
 		defer pb.Close()
 
 		r = io.TeeReader(bin, pb)

--- a/pkg/cli/updater/updater.go
+++ b/pkg/cli/updater/updater.go
@@ -17,12 +17,12 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/briandowns/spinner"
 	"github.com/fynelabs/selfupdate"
 	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/gobox/pkg/cfg"
 	"github.com/getoutreach/gobox/pkg/cli/github"
 	"github.com/getoutreach/gobox/pkg/cli/progress"
+	"github.com/getoutreach/gobox/pkg/cli/spinner"
 	"github.com/getoutreach/gobox/pkg/cli/updater/archive"
 	"github.com/getoutreach/gobox/pkg/cli/updater/release"
 	"github.com/getoutreach/gobox/pkg/cli/updater/resolver"
@@ -316,8 +316,7 @@ func (u *updater) check(ctx context.Context) (bool, error) {
 	}
 
 	// Start the checking for updates spinner
-	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond,
-		spinner.WithSuffix(" Checking for updates..."))
+	spin := spinner.New("Checking for updates...")
 	spin.Start()
 
 	v, err := resolver.Resolve(ctx, u.ghToken, &resolver.Criteria{


### PR DESCRIPTION
## What this PR does / why we need it

Adds `pkg/cli/progress` and `pkg/cli/spinner`, small byte-progress and animated-spinner helpers built on `charm.land/bubbles/v2`, and switches `pkg/cli/updater` over to them. This follows the pattern `pkg/cli/prompt` already established for terminal UI on top of Bubble Tea, and lets us drop `github.com/schollz/progressbar/v3` and `github.com/briandowns/spinner` entirely. Both packages call the underlying `bubbles/v2` render methods directly rather than running a full `tea.Program`, since neither needs an event loop or interactive input — just a redrawn status line alongside a blocking download or network call.

`pkg/cli/internal/term` factors out the terminal-detection, width, and clear-line logic the two new packages would otherwise duplicate, and is now also used by `pkg/cli/updater` and `pkg/cli/logfile`, which had their own inline copies of the same terminal check. `progress.Bytes` uses it to re-check the terminal width on every redraw and resize its bar to fit, the same way `schollz/progressbar`'s `OptionFullWidth` did — a synchronous size check before each draw, no Bubble Tea event loop required.

## Notes for your reviewers

- Verified against a second, independent consumer of this dependency to confirm the new API works outside gobox itself, not just within it: pointed that consumer's `gobox` dependency at this branch, swapped its equivalent `progressbar.DefaultBytes` call sites over to `progress.NewBytes`, and added a functional test exercising the real download path through the new writer. Everything built and passed.
- `pkg/olog/default_handler.go` has the same inline terminal-detection duplicate `pkg/cli/internal/term` replaces elsewhere, but it sits outside `pkg/cli`'s internal-package visibility and is owned by a different team (`@getoutreach/observability`), so it's left as a follow-up rather than folded in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToX4Pc4RHcndVyKbmo7GKx)_