### PR TITLE
feat(cli): add Telemetry.Disabled flag to fully turn off tracing

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -57,7 +57,7 @@ func setupRun(
 	// Ensure that we don't use the standard outreach logger
 	log.SetOutput(io.Discard)
 
-	if conf.Telemetry.UseDelibird {
+	if conf.Telemetry.useDelibird() {
 		logger.Debug("Using delibird for telemetry")
 		if err := logfile.Hook(); err != nil {
 			logger.WithError(err).Warn("Failed to capture logs, continuing without logging to file")
@@ -71,9 +71,13 @@ func setupRun(
 	// Cancel the context on ^C and other signals
 	urfaveRegisterShutdownHandler(cancel)
 
-	// Setup tracing, with a top-level span being the name of the application
-	if err := trace.InitTracer(ctx, app.Info().Name); err != nil {
-		logger.WithError(err).Warn("Failed to initialize tracer")
+	// Setup tracing, with a top-level span being the name of the application. Skipped
+	// entirely when telemetry is intentionally disabled, since trace.InitTracer would
+	// otherwise log a "no tracer configured" warning on every run.
+	if !conf.Telemetry.Disabled {
+		if err := trace.InitTracer(ctx, app.Info().Name); err != nil {
+			logger.WithError(err).Warn("Failed to initialize tracer")
+		}
 	}
 	ctx = trace.StartSpan(ctx, app.Info().Name, trace.CommonProps())
 

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -31,6 +31,18 @@ type Config struct {
 
 // TelemetryConfig is the configuration for telemetry for the CLI
 type TelemetryConfig struct {
+	// Disabled intentionally turns off all telemetry for the CLI, regardless of
+	// UseDelibird, Otel, or a mounted trace.yaml.
+	//
+	// This framework normally overrides the mounted trace.yaml with a synthesized
+	// config that always enables OpenTelemetry tracing to Honeycomb using an API
+	// key compiled into the binary. CLIs that don't have a valid Honeycomb API key
+	// (for example, cron jobs built with stencil-golang) should set this instead of
+	// relying on trace.yaml, since that file is otherwise ignored here and setting
+	// `OpenTelemetry.Enabled: false` in it has no effect, producing continuous
+	// "unknown API key" export errors. Takes priority over UseDelibird.
+	Disabled bool
+
 	// UseDelibird enables the delibird integration, which logs all output to a
 	// file as frames (writes to the terminal) as well as records traces.
 	//
@@ -41,6 +53,12 @@ type TelemetryConfig struct {
 
 	// Otel is the configuration for telemetry when delibird is not in use.
 	Otel TelemetryOtelConfig
+}
+
+// useDelibird reports whether delibird-based telemetry should be used.
+// Disabled always takes priority over UseDelibird.
+func (t TelemetryConfig) useDelibird() bool {
+	return !t.Disabled && t.UseDelibird
 }
 
 // TelemetryOtelConfig is the configuration for telemetry when delibird is not in use.
@@ -82,7 +100,7 @@ func useEmbeddedHoneycombAPIKey(honeycombAPIKey cfg.SecretData) {
 // overrideConfigLoaders fakes certain parts of the config that usually get pulled
 // in via mechanisms that don't make sense to use in CLIs.
 func overrideConfigLoaders(conf *Config) {
-	if !conf.Telemetry.UseDelibird {
+	if !conf.Telemetry.Disabled && !conf.Telemetry.UseDelibird {
 		useEmbeddedHoneycombAPIKey(conf.Telemetry.Otel.HoneycombAPIKey)
 	}
 
@@ -91,7 +109,12 @@ func overrideConfigLoaders(conf *Config) {
 		// try to use fake file first
 		if fileName == "trace.yaml" {
 			var traceConfig *trace.Config
-			if conf.Telemetry.UseDelibird {
+			switch {
+			case conf.Telemetry.Disabled:
+				// Report every tracer as off so gobox never attempts to connect
+				// anywhere, instead of hardcoding OpenTelemetry on below.
+				traceConfig = &trace.Config{}
+			case conf.Telemetry.useDelibird():
 				portStr := os.Getenv(logfile.TracePortEnvironmentVariable)
 				if portStr == "" {
 					return nil, fmt.Errorf("delibird enabled, but %s not set", logfile.TracePortEnvironmentVariable)
@@ -108,7 +131,7 @@ func overrideConfigLoaders(conf *Config) {
 						Port:    port,
 					},
 				}
-			} else {
+			default:
 				traceConfig = &trace.Config{
 					Otel: trace.Otel{
 						Enabled:  true,

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+// Description: Tests for config.go
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/getoutreach/gobox/pkg/cfg"
+	"github.com/getoutreach/gobox/pkg/trace"
+	"gotest.tools/v3/assert"
+)
+
+// TestOverrideConfigLoadersDisabledTelemetry ensures that setting
+// Config.Telemetry.Disabled results in a trace.yaml override that reports
+// tracing as fully disabled, instead of the default behavior of hardcoding
+// OpenTelemetry on.
+func TestOverrideConfigLoadersDisabledTelemetry(t *testing.T) {
+	originalReader := cfg.DefaultReader()
+	defer cfg.SetDefaultReader(originalReader)
+
+	overrideConfigLoaders(&Config{
+		Telemetry: TelemetryConfig{Disabled: true},
+	})
+
+	var traceConfig trace.Config
+	assert.NilError(t, cfg.Load("trace.yaml", &traceConfig))
+	assert.DeepEqual(t, traceConfig, trace.Config{})
+}
+
+// TestOverrideConfigLoadersEnabledTelemetry ensures the pre-existing
+// behavior is unchanged when Disabled is not set: OpenTelemetry is
+// hardcoded on regardless of what a mounted trace.yaml contains.
+func TestOverrideConfigLoadersEnabledTelemetry(t *testing.T) {
+	originalReader := cfg.DefaultReader()
+	defer cfg.SetDefaultReader(originalReader)
+
+	overrideConfigLoaders(&Config{
+		Telemetry: TelemetryConfig{
+			Otel: TelemetryOtelConfig{Dataset: "test-dataset"},
+		},
+	})
+
+	var traceConfig trace.Config
+	assert.NilError(t, cfg.Load("trace.yaml", &traceConfig))
+	assert.DeepEqual(t, traceConfig, trace.Config{
+		Otel: trace.Otel{
+			Enabled:  true,
+			Endpoint: "api.honeycomb.io",
+			APIKey: cfg.Secret{
+				Path: "APIKey",
+			},
+			Dataset:       "test-dataset",
+			SamplePercent: 100,
+		},
+	})
+}


### PR DESCRIPTION
## What this PR does / why we need it

Cron job CLIs built on gobox's `pkg/cli` framework can't disable OpenTelemetry tracing through a mounted `trace.yaml`, because `overrideConfigLoaders` always overrides it and hardcodes `OpenTelemetry.Enabled: true` unless `UseDelibird` is set. Jobs without a valid compiled-in Honeycomb API key emit continuous "unknown API key" export errors as a result.

Adds a `Telemetry.Disabled` field to `cli.Config` that CLI authors can set to make tracing setup a full no-op: `overrideConfigLoaders` skips the embedded-key setup and reports every tracer as off, and `setupRun` skips the `trace.InitTracer` call so no "no tracer configured" warning is logged either.

## Jira ID

[DT-4792]

## Notes for your reviewers

This requires each affected downstream CLI to set `Telemetry: cli.TelemetryConfig{Disabled: true}` after bumping gobox — it isn't automatic based on whether a Honeycomb key is present. That matches the triage decision recorded on the ticket, which explicitly rejected auto-disabling on a missing/empty key in favor of an explicit opt-in flag.

---
_Generated by [Claude Code](https://claude.ai/code/session_017BpFnYHyVDi3eXziisZd2S)_

[DT-4792]: https://outreach-io.atlassian.net/browse/DT-4792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ