### PR TITLE
fix(trace): stop InitTracer installing a noop global MeterProvider

### DIFF
--- a/pkg/trace/otel.go
+++ b/pkg/trace/otel.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -89,9 +88,6 @@ func (t *otelTracer) registerSpanProcessor(s sdktrace.SpanProcessor) {
 }
 
 func (t *otelTracer) initTracer(ctx context.Context, serviceName string) error {
-	mp := noop.NewMeterProvider()
-	otel.SetMeterProvider(mp)
-
 	var client otlptrace.Client
 
 	// We want to default to initialize and send traces through the OpenTelemetry collectors.


### PR DESCRIPTION
## What
Delete unconditional `otel.SetMeterProvider(noop)` in `initTracer` (+ unused import). 4 lines removed.

## Why
`trace.InitTracer` clobber real meter provider if service install one (order-dependent). Root cause of polaroid silent OTLP metric drop + FND-1013. No single owner of global.

## Safety analysis
- Noop line exist to guard otel-go global-delegate unbounded memory leak ([#5753](https://github.com/open-telemetry/opentelemetry-go/issues/5753)). Leak fixed upstream v1.30.0 ([#5754](https://github.com/open-telemetry/opentelemetry-go/pull/5754), follow-ups [#5780](https://github.com/open-telemetry/opentelemetry-go/pull/5780), [#5828](https://github.com/open-telemetry/opentelemetry-go/pull/5828)). gobox pin otel v1.45.0; Go MVS force all importers >= v1.45.0. Guard obsolete.
- Global delegate now dedupe identical instruments: memory bounded by unique instrument count. Measurements before real provider drop, never buffer — same as noop.
- `pkg/trace/logfile.go` noop-set untouched: dev/logfile/tracetest path behavior identical.
- Tests: `go test -tags or_test ./pkg/trace` — 11 fail with change, identical 11 fail on clean main (all `app.version "testing"` vs `"(devel)"` ldflags env artifact, unrelated). No regression.
- Build clean after removing unused `metric/noop` import.

## Behavior change (intended)
- Service that install real meter provider: no longer clobbered by `InitTracer`, any call order. Polaroid delete workaround after this.
- Service that never set provider: global stay delegating instead of noop. If real provider installed later, previously-dead metrics start exporting. Correct behavior, but silent metrics may appear after redeploy (dashboards, ingest volume) — heads up.

## Refs
FND-1013, FND-955, gobox #214 (introduced the guard)