### PR TITLE
feat(env): add envtest so FakeTestConfig works without build tags

### DIFF
--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/getoutreach/gobox/pkg/cfg"
-	"github.com/getoutreach/gobox/pkg/env"
+	"github.com/getoutreach/gobox/pkg/env/envtest"
 	"github.com/getoutreach/gobox/pkg/secrets/secretstest"
 )
 
@@ -26,7 +26,7 @@ func Example() {
 		Key:        cfg.Secret{Path: "someSecretPath"},
 	}
 
-	deleteFunc, _ := env.FakeTestConfigWithError("trace.yaml", expected)
+	deleteFunc, _ := envtest.FakeTestConfigWithError("trace.yaml", expected)
 	defer deleteFunc()
 	defer secretstest.Fake("someSecretPath", "someSecretData")()
 

--- a/pkg/env/e2eenv.go
+++ b/pkg/env/e2eenv.go
@@ -7,11 +7,14 @@
 
 package env
 
-import "github.com/getoutreach/gobox/pkg/cfg"
+import (
+	"github.com/getoutreach/gobox/pkg/cfg"
+	"github.com/getoutreach/gobox/pkg/env/envtest"
+)
 
 func ApplyOverrides() {
-	old := cfg.DefaultReader()
-	cfg.SetDefaultReader(testReader(devReader(old), &overrides))
+	cfg.SetDefaultReader(devReader(cfg.DefaultReader()))
+	envtest.Install()
 }
 
 func init() { //nolint:gochecknoinits // Why: On purpose.

--- a/pkg/env/envtest/envtest.go
+++ b/pkg/env/envtest/envtest.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+// Package envtest provides test configuration overrides.
+//
+// It carries no build constraint, so test helpers that fake config compile
+// under any build. Faking is opt-in at runtime rather than at build time: an
+// override only takes effect once FakeTestConfig installs the override reader,
+// so a binary that never calls it reads config exactly as it would in
+// production.
+package envtest
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/getoutreach/gobox/pkg/cfg"
+	"go.yaml.in/yaml/v3"
+)
+
+type testOverrides struct {
+	data map[string]interface{}
+	mu   sync.Mutex
+}
+
+func (to *testOverrides) addWithError(k string, v interface{}) error {
+	to.mu.Lock()
+	defer to.mu.Unlock()
+
+	if _, exists := to.data[k]; exists {
+		return fmt.Errorf("repeated test override of '%s'", k)
+	}
+
+	to.data[k] = v
+	return nil
+}
+
+func (to *testOverrides) load(k string) (interface{}, bool) {
+	to.mu.Lock()
+	defer to.mu.Unlock()
+
+	// Apparently you cannot pull the bool out of this access implicitly in the return
+	// statement.
+	v, ok := to.data[k]
+
+	return v, ok
+}
+
+func (to *testOverrides) delete(k string) {
+	to.mu.Lock()
+	defer to.mu.Unlock()
+
+	delete(to.data, k)
+}
+
+// nolint:gochecknoglobals // Why: needs to be overridable
+var overrides = testOverrides{
+	data: make(map[string]interface{}),
+}
+
+// nolint:gochecknoglobals // Why: guards a one-time process-wide install
+var installOnce sync.Once
+
+// Install routes config reads through the override table, wrapping whatever
+// reader is currently installed. It is idempotent and is called automatically
+// by FakeTestConfig, so tests rarely need to call it directly.
+func Install() {
+	installOnce.Do(func() {
+		cfg.SetDefaultReader(reader(cfg.DefaultReader()))
+	})
+}
+
+// reader returns a cfg.Reader serving registered overrides, falling back to
+// fallback for names with no override.
+func reader(fallback cfg.Reader) cfg.Reader {
+	return cfg.Reader(func(fileName string) ([]byte, error) {
+		if override, ok := overrides.load(fileName); ok {
+			return yaml.Marshal(override)
+		}
+		return fallback(fileName)
+	})
+}
+
+// FakeTestConfig allows you to fake the test config with a specific value.
+//
+// The provided value is serialized to yaml and so can be structured data.
+//
+// Be extra careful when using this function in parallelized tests - do not
+// use the fName across two tests running in parallel. This will cause the
+// function to potentially panic.
+//
+// Please use `FakeTestConfigWithError` if you want an error returned rather than panicking
+func FakeTestConfig(fName string, ptr interface{}) func() {
+	// add ensures that it doesn't already exist to prevent two tests running
+	// concurrently colliding on fName.
+	f, err := FakeTestConfigWithError(fName, ptr)
+	if err != nil {
+		panic(fmt.Sprintf("failed to addHandler '%v'. Use the function 'FakeTestConfigWithError()' to capture the err message", err.Error()))
+	}
+	return f
+}
+
+// FakeTestConfigWithError allows you to fake the test config with a specific value
+// and returns an error if a config with the same name exists already. If callers get an error,
+// they should switch to running tests in serial.
+func FakeTestConfigWithError(fName string, ptr interface{}) (func(), error) {
+	Install()
+
+	err := overrides.addWithError(fName, ptr)
+	if err != nil {
+		return nil, err
+	}
+
+	return func() {
+		overrides.delete(fName)
+	}, nil
+}

--- a/pkg/env/envtest/envtest_test.go
+++ b/pkg/env/envtest/envtest_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+// Description: Unit tests for the envtest config overrides
+
+package envtest_test
+
+import (
+	"testing"
+
+	"github.com/getoutreach/gobox/pkg/cfg"
+	"github.com/getoutreach/gobox/pkg/env/envtest"
+	"gotest.tools/v3/assert"
+)
+
+type listenConfig struct {
+	ListenHost string `yaml:"ListenHost"`
+	HTTPPort   int    `yaml:"HTTPPort"`
+}
+
+// TestFakeTestConfigServesOverrideWithoutBuildTags asserts that a faked config
+// is readable through cfg.Load in a build with no or_* tags set. This file
+// carries no build constraint on purpose: it is the regression guard for
+// callers that cannot set build tags.
+func TestFakeTestConfigServesOverrideWithoutBuildTags(t *testing.T) {
+	cleanup := envtest.FakeTestConfig("envtest_serves.yaml", listenConfig{
+		ListenHost: "someURL",
+		HTTPPort:   8080,
+	})
+	defer cleanup()
+
+	var got listenConfig
+	assert.NilError(t, cfg.Load("envtest_serves.yaml", &got))
+	assert.Equal(t, got.ListenHost, "someURL")
+	assert.Equal(t, got.HTTPPort, 8080)
+}
+
+// TestCleanupRemovesOverride asserts the returned function unregisters the
+// override, so a later read falls through to the underlying reader.
+func TestCleanupRemovesOverride(t *testing.T) {
+	cleanup := envtest.FakeTestConfig("envtest_cleanup.yaml", listenConfig{ListenHost: "gone"})
+
+	var got listenConfig
+	assert.NilError(t, cfg.Load("envtest_cleanup.yaml", &got))
+	assert.Equal(t, got.ListenHost, "gone")
+
+	cleanup()
+
+	assert.Assert(t, cfg.Load("envtest_cleanup.yaml", &got) != nil)
+}
+
+// TestFakeTestConfigWithErrorRejectsRepeatedName asserts that faking the same
+// name twice reports an error rather than silently clobbering the first value.
+func TestFakeTestConfigWithErrorRejectsRepeatedName(t *testing.T) {
+	cleanup, err := envtest.FakeTestConfigWithError("envtest_repeat.yaml", listenConfig{})
+	assert.NilError(t, err)
+	defer cleanup()
+
+	_, err = envtest.FakeTestConfigWithError("envtest_repeat.yaml", listenConfig{})
+	assert.Error(t, err, "repeated test override of 'envtest_repeat.yaml'")
+}

--- a/pkg/env/faketestconfig.go
+++ b/pkg/env/faketestconfig.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+// Description: Compatibility wrappers for the envtest config overrides
+
+package env
+
+import (
+	"github.com/getoutreach/gobox/pkg/env/envtest"
+)
+
+// FakeTestConfig fakes the config named fName with ptr, returning a function
+// that removes the override. New code should call envtest.FakeTestConfig.
+func FakeTestConfig(fName string, ptr interface{}) func() {
+	return envtest.FakeTestConfig(fName, ptr)
+}
+
+// FakeTestConfigWithError fakes the config named fName with ptr, returning a
+// function that removes the override, or an error if fName is already faked.
+// New code should call envtest.FakeTestConfigWithError.
+func FakeTestConfigWithError(fName string, ptr interface{}) (func(), error) {
+	return envtest.FakeTestConfigWithError(fName, ptr)
+}

--- a/pkg/env/readers.go
+++ b/pkg/env/readers.go
@@ -8,56 +8,13 @@
 package env
 
 import (
-	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
-	"sync"
 
 	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/gobox/pkg/cfg"
-	"go.yaml.in/yaml/v3"
 )
-
-type testOverrides struct {
-	data map[string]interface{}
-	mu   sync.Mutex
-}
-
-func (to *testOverrides) addWithError(k string, v interface{}) error {
-	to.mu.Lock()
-	defer to.mu.Unlock()
-
-	if _, exists := to.data[k]; exists {
-		return fmt.Errorf("repeated test override of '%s'", k)
-	}
-
-	to.data[k] = v
-	return nil
-}
-
-func (to *testOverrides) load(k string) (interface{}, bool) {
-	to.mu.Lock()
-	defer to.mu.Unlock()
-
-	// Apparently you cannot pull the bool out of this access implicitly in the return
-	// statement.
-	v, ok := to.data[k]
-
-	return v, ok
-}
-
-func (to *testOverrides) delete(k string) {
-	to.mu.Lock()
-	defer to.mu.Unlock()
-
-	delete(to.data, k)
-}
-
-// nolint:gochecknoglobals // Why: needs to be overridable
-var overrides = testOverrides{
-	data: make(map[string]interface{}),
-}
 
 // devReader creates a config reader specific to the dev environment.
 func devReader(fallback cfg.Reader) cfg.Reader { //nolint:deadcode,unused // Why: only used with certain build tags
@@ -94,46 +51,4 @@ func devReader(fallback cfg.Reader) cfg.Reader { //nolint:deadcode,unused // Why
 
 		return b, nil
 	})
-}
-
-func testReader(fallback cfg.Reader, overrider *testOverrides) cfg.Reader {
-	return cfg.Reader(func(fileName string) ([]byte, error) {
-		if override, ok := overrider.load(fileName); ok {
-			return yaml.Marshal(override)
-		}
-		return fallback(fileName)
-	})
-}
-
-// FakeTestConfig allows you to fake the test config with a specific value.
-//
-// The provided value is serialized to yaml and so can be structured data.
-//
-// Be extra careful when using this function in parallelized tests - do not
-// use the fName across two tests running in parallel. This will cause the
-// function to potentially panic.
-//
-// Please use `FakeTestConfigWithError` if you want an error returned rather than panicking
-func FakeTestConfig(fName string, ptr interface{}) func() {
-	// add ensures that it doesn't already exist to prevent two tests running
-	// concurrently colliding on fName.
-	f, err := FakeTestConfigWithError(fName, ptr)
-	if err != nil {
-		panic(fmt.Sprintf("failed to addHandler '%v'. Use the function 'FakeTestConfigWithError()' to capture the err message", err.Error()))
-	}
-	return f
-}
-
-// FakeTestConfigWithError allows you to fake the test config with a specific value
-// and returns an error if a config with the same name exists already. If callers get an error,
-// they should switch to running tests in serial.
-func FakeTestConfigWithError(fName string, ptr interface{}) (func(), error) {
-	err := overrides.addWithError(fName, ptr)
-	if err != nil {
-		return nil, err
-	}
-
-	return func() {
-		overrides.delete(fName)
-	}, nil
 }

--- a/pkg/env/testenv.go
+++ b/pkg/env/testenv.go
@@ -5,12 +5,11 @@
 package env
 
 import (
-	"github.com/getoutreach/gobox/pkg/cfg"
+	"github.com/getoutreach/gobox/pkg/env/envtest"
 )
 
 func ApplyOverrides() {
-	old := cfg.DefaultReader()
-	cfg.SetDefaultReader(testReader(old, &overrides))
+	envtest.Install()
 }
 
 func init() { //nolint: gochecknoinits

--- a/pkg/trace/tracetest/tracetest.go
+++ b/pkg/trace/tracetest/tracetest.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	clean "github.com/getoutreach/gobox/pkg/cleanup"
-	"github.com/getoutreach/gobox/pkg/env"
+	"github.com/getoutreach/gobox/pkg/env/envtest"
 	"github.com/getoutreach/gobox/pkg/secrets/secretstest"
 	"github.com/getoutreach/gobox/pkg/trace"
 	"go.opentelemetry.io/otel/attribute"
@@ -56,7 +56,7 @@ func NewSpanRecorderWithOptions(options Options) *SpanRecorder {
 		}
 	}
 
-	restoreConfig, err := env.FakeTestConfigWithError("trace.yaml", fakeConfig)
+	restoreConfig, err := envtest.FakeTestConfigWithError("trace.yaml", fakeConfig)
 	assert.NilError(nil, err)
 
 	ctx := context.Background()
@@ -170,7 +170,7 @@ func (sr *SpanRecorder) Ended() []map[string]interface{} {
 // The cleanup function resets the tracing secrets and configuration.
 func Disabled() (cleanup func()) {
 	cleanupSecrets := secretstest.Fake("/etc/.honeycomb_api_key", "some fake value")
-	cleanupCfg, err := env.FakeTestConfigWithError("trace.yaml", map[string]interface{}{
+	cleanupCfg, err := envtest.FakeTestConfigWithError("trace.yaml", map[string]interface{}{
 		"Otel": map[string]interface{}{
 			"Enabled": false,
 		},


### PR DESCRIPTION
[QSS-1750](https://outreach-io.atlassian.net/browse/QSS-1750)

`pkg/env` exposes `FakeTestConfig` only under `or_test`/`or_dev`/`or_e2e`/`or_int`. Build tags are global to a build command, so every downstream consumer's test binary inherits the requirement. gobox itself is affected on `main`:

```
$ go build ./pkg/trace/tracetest/
pkg/trace/tracetest/tracetest.go:59:28: undefined: env.FakeTestConfigWithError
```

- Moves the override table into `pkg/env/envtest`, which carries no build constraint — the shape `pkg/log/logtest`, `pkg/secrets/secretstest` and `pkg/trace/tracetest` already use.
- An override applies only once `FakeTestConfig` installs the reader, so a binary that never calls it is unchanged.
- `env.FakeTestConfig` stays as an untagged wrapper, so no consumer changes. Not marked `Deprecated`: `SA1019` is an error under golangci-lint, and at least 32 files across 16 repos call it today.

Earlier attempts: #261, #714. Mint half: getoutreach/mint#643.


[QSS-1750]: https://outreach-io.atlassian.net/browse/QSS-1750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ