### PR TITLE
feat(box): add PostRestoreServerSide to SnapshotTarget

### DIFF
--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -250,13 +250,8 @@ type SnapshotTarget struct {
 	PostRestore string `yaml:"post_restore"`
 
 	// PostRestoreServerSide are paths to yaml files applied after PostRestore
-	// with a server-side apply, in the order listed. Each file is rendered
-	// through the same go-template as PostRestore.
-	//
-	// Use this for manifests a client-side apply cannot handle, such as
-	// resources whose annotations would exceed kubectl's last-applied limit.
-	// Ordering is honoured so a file may depend on an earlier one, e.g. custom
-	// resources listed after the CRDs and operator that reconcile them.
+	// with a server-side apply, in the order listed. Use it for manifests a
+	// client-side apply cannot handle, such as very large resources.
 	PostRestoreServerSide []string `yaml:"post_restore_server_side"`
 
 	// DeployApps is an array of applications to deploy via deploy-app

--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -249,6 +249,16 @@ type SnapshotTarget struct {
 	// injecting information like the current user / git email.
 	PostRestore string `yaml:"post_restore"`
 
+	// PostRestoreServerSide are paths to yaml files applied after PostRestore
+	// with a server-side apply, in the order listed. Each file is rendered
+	// through the same go-template as PostRestore.
+	//
+	// Use this for manifests a client-side apply cannot handle, such as
+	// resources whose annotations would exceed kubectl's last-applied limit.
+	// Ordering is honoured so a file may depend on an earlier one, e.g. custom
+	// resources listed after the CRDs and operator that reconcile them.
+	PostRestoreServerSide []string `yaml:"post_restore_server_side"`
+
 	// DeployApps is an array of applications to deploy via deploy-app
 	// before running the Command specified.
 	DeployApps []string `yaml:"deploy_apps"`

--- a/pkg/box/snapshottarget_test.go
+++ b/pkg/box/snapshottarget_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/getoutreach/gobox/pkg/box"
 )
 
-// TestSnapshotTargetPostRestoreServerSide checks the ordered list round-trips,
-// since consumers apply the files in the order given.
+// TestSnapshotTargetPostRestoreServerSide checks the ordered list round-trips.
 func TestSnapshotTargetPostRestoreServerSide(t *testing.T) {
 	var c box.SnapshotGenerateConfig
 	assert.NilError(t, yaml.Unmarshal([]byte(`
@@ -34,8 +33,7 @@ targets:
 	})
 }
 
-// TestSnapshotTargetOmitted covers the common case: a target that does not use
-// the field leaves it nil rather than failing to parse.
+// TestSnapshotTargetOmitted checks an unset field stays nil.
 func TestSnapshotTargetOmitted(t *testing.T) {
 	var c box.SnapshotGenerateConfig
 	assert.NilError(t, yaml.Unmarshal([]byte(`
@@ -47,10 +45,8 @@ targets:
 	assert.Assert(t, c.Targets["base"].PostRestoreServerSide == nil)
 }
 
-// TestSnapshotTargetIgnoresUnknownKeys pins the lenient-parse behaviour that
-// lets a snapshots.yaml using a newer field be read by an older consumer: the
-// unknown key is skipped rather than erroring. Rollouts rely on this, so a
-// switch to a strict decoder should be a deliberate decision.
+// TestSnapshotTargetIgnoresUnknownKeys pins the lenient parse that lets an older
+// consumer read a newer snapshots.yaml. A strict decoder should be a deliberate choice.
 func TestSnapshotTargetIgnoresUnknownKeys(t *testing.T) {
 	var c box.SnapshotGenerateConfig
 	assert.NilError(t, yaml.Unmarshal([]byte(`

--- a/pkg/box/snapshottarget_test.go
+++ b/pkg/box/snapshottarget_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+// Description: Tests SnapshotTarget's YAML contract with snapshots.yaml.
+
+package box_test
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+	"gotest.tools/v3/assert"
+
+	"github.com/getoutreach/gobox/pkg/box"
+)
+
+// TestSnapshotTargetPostRestoreServerSide checks the ordered list round-trips,
+// since consumers apply the files in the order given.
+func TestSnapshotTargetPostRestoreServerSide(t *testing.T) {
+	var c box.SnapshotGenerateConfig
+	assert.NilError(t, yaml.Unmarshal([]byte(`
+targets:
+  base:
+    post_restore: ./post-restore/manifests.yaml
+    post_restore_server_side:
+      - ./post-restore/opentelemetry-operator.yaml
+      - ./post-restore/otel-collectors.yaml
+`), &c))
+
+	target := c.Targets["base"]
+	assert.Equal(t, target.PostRestore, "./post-restore/manifests.yaml")
+	assert.DeepEqual(t, target.PostRestoreServerSide, []string{
+		"./post-restore/opentelemetry-operator.yaml",
+		"./post-restore/otel-collectors.yaml",
+	})
+}
+
+// TestSnapshotTargetOmitted covers the common case: a target that does not use
+// the field leaves it nil rather than failing to parse.
+func TestSnapshotTargetOmitted(t *testing.T) {
+	var c box.SnapshotGenerateConfig
+	assert.NilError(t, yaml.Unmarshal([]byte(`
+targets:
+  base:
+    post_restore: ./post-restore/manifests.yaml
+`), &c))
+
+	assert.Assert(t, c.Targets["base"].PostRestoreServerSide == nil)
+}
+
+// TestSnapshotTargetIgnoresUnknownKeys pins the lenient-parse behaviour that
+// lets a snapshots.yaml using a newer field be read by an older consumer: the
+// unknown key is skipped rather than erroring. Rollouts rely on this, so a
+// switch to a strict decoder should be a deliberate decision.
+func TestSnapshotTargetIgnoresUnknownKeys(t *testing.T) {
+	var c box.SnapshotGenerateConfig
+	assert.NilError(t, yaml.Unmarshal([]byte(`
+targets:
+  base:
+    post_restore: ./post-restore/manifests.yaml
+    some_field_from_the_future: [a, b]
+`), &c))
+
+	assert.Equal(t, c.Targets["base"].PostRestore, "./post-restore/manifests.yaml")
+}


### PR DESCRIPTION
Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

## What this PR does / why we need it

Adds one field to `SnapshotTarget`:

```go
// PostRestoreServerSide are paths to yaml files applied after PostRestore
// with a server-side apply, in the order listed.
PostRestoreServerSide []string `yaml:"post_restore_server_side"`
```

devenv applies a snapshot's post-restore manifests **client-side**, which cannot carry resources whose last-applied annotation would exceed kubectl's 262KB limit. Switching the existing apply to server-side would change the semantics of everything already going through it (Datadog, CoreDNS, VaultSecrets in devenv-snapshots), so this adds a parallel channel rather than altering the existing one.

The list is **ordered** because consumers apply the files in sequence, letting a file depend on an earlier one — custom resources listed after the CRDs and operator that reconcile them being the motivating case.

Schema only. Nothing reads the field yet; devenv picks it up in a follow-up, and devenv-snapshots then starts populating it.

## Jira ID

[FND-1045](https://outreach-io.atlassian.net/browse/FND-1045)

## Notes for your reviewers

**Why gobox and not devenv:** `SnapshotTarget` is the shared schema for `snapshots.yaml`, and both devenv and devenv-snapshots read it from here.

**Backwards compatible in both directions.** The field is additive and optional, so existing `snapshots.yaml` files are unaffected. More importantly for the rollout, a `snapshots.yaml` that *uses* the field can still be read by an older consumer: `yaml.Unmarshal` skips unknown keys rather than erroring, so an older devenv generates today's snapshot minus the new payload instead of failing. That ordering property is what lets the content repo merge ahead of the consumer, so I pinned it in a test — a future switch to a strict decoder should be a deliberate decision, not an accident.

**Tests** (`pkg/box/snapshottarget_test.go`, first test file in this package): ordered round-trip, omitted field stays nil, and the unknown-key tolerance above.

`go build`, `go test ./pkg/box/` and `make lint` all pass.

[FND-1045]: https://outreach-io.atlassian.net/browse/FND-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

