### PR TITLE
feat(orerr): respect gRPC status and context errors in classification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
-	google.golang.org/grpc v1.83.0 // indirect
+	google.golang.org/grpc v1.83.0
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/pkg/orerr/statuscodewrap.go
+++ b/pkg/orerr/statuscodewrap.go
@@ -114,6 +114,8 @@ func grpcCodeToStatusCode(code codes.Code) statuscodes.StatusCode {
 		return statuscodes.Cancelled
 	case codes.AlreadyExists:
 		return statuscodes.Conflict
+	case codes.Unknown, codes.FailedPrecondition, codes.Aborted, codes.OutOfRange, codes.DataLoss:
+		return statuscodes.InternalServerError
 	default:
 		return statuscodes.InternalServerError
 	}

--- a/pkg/orerr/statuscodewrap.go
+++ b/pkg/orerr/statuscodewrap.go
@@ -5,9 +5,12 @@
 package orerr
 
 import (
+	"context"
 	"errors"
 
 	"github.com/getoutreach/gobox/pkg/statuscodes"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type StatusCodeWrapper struct {
@@ -62,13 +65,56 @@ func ExtractErrorStatusCode(err error) statuscodes.StatusCode {
 	if errors.As(err, &scw) {
 		return scw.StatusCode()
 	}
+
+	if errors.Is(err, context.Canceled) {
+		return statuscodes.Cancelled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return statuscodes.DeadlineExceeded
+	}
+
+	var grpcStatus interface{ GRPCStatus() *status.Status }
+	if errors.As(err, &grpcStatus) {
+		if st := grpcStatus.GRPCStatus(); st != nil {
+			return grpcCodeToStatusCode(st.Code())
+		}
+	}
+
 	return statuscodes.InternalServerError
 }
 
 func ExtractErrorStatusCategory(err error) statuscodes.StatusCategory {
-	var scw *StatusCodeWrapper
-	if errors.As(err, &scw) {
-		return scw.StatusCategory()
+	code := ExtractErrorStatusCode(err)
+	return code.Category()
+}
+
+func grpcCodeToStatusCode(code codes.Code) statuscodes.StatusCode {
+	switch code {
+	case codes.OK:
+		return statuscodes.OK
+	case codes.InvalidArgument:
+		return statuscodes.BadRequest
+	case codes.Unauthenticated:
+		return statuscodes.Unauthorized
+	case codes.PermissionDenied:
+		return statuscodes.Forbidden
+	case codes.NotFound:
+		return statuscodes.NotFound
+	case codes.ResourceExhausted:
+		return statuscodes.RateLimited
+	case codes.Internal:
+		return statuscodes.InternalServerError
+	case codes.Unimplemented:
+		return statuscodes.NotImplemented
+	case codes.Unavailable:
+		return statuscodes.Unavailable
+	case codes.DeadlineExceeded:
+		return statuscodes.DeadlineExceeded
+	case codes.Canceled:
+		return statuscodes.Cancelled
+	case codes.AlreadyExists:
+		return statuscodes.Conflict
+	default:
+		return statuscodes.InternalServerError
 	}
-	return statuscodes.CategoryServerError
 }

--- a/pkg/orerr/statuscodewrap.go
+++ b/pkg/orerr/statuscodewrap.go
@@ -114,7 +114,13 @@ func grpcCodeToStatusCode(code codes.Code) statuscodes.StatusCode {
 		return statuscodes.Cancelled
 	case codes.AlreadyExists:
 		return statuscodes.Conflict
-	case codes.Unknown, codes.FailedPrecondition, codes.Aborted, codes.OutOfRange, codes.DataLoss:
+	case codes.FailedPrecondition, codes.Aborted:
+		return statuscodes.Conflict
+	case codes.OutOfRange:
+		return statuscodes.BadRequest
+	case codes.Unknown:
+		return statuscodes.UnknownError
+	case codes.DataLoss:
 		return statuscodes.InternalServerError
 	default:
 		return statuscodes.InternalServerError

--- a/pkg/orerr/statuscodewrap_grpc_test.go
+++ b/pkg/orerr/statuscodewrap_grpc_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/getoutreach/gobox/pkg/orerr"
 	"github.com/getoutreach/gobox/pkg/statuscodes"
-	"gotest.tools/v3/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"gotest.tools/v3/assert"
 )
 
 func TestExtractErrorStatusCode_GRPCStatus(t *testing.T) {

--- a/pkg/orerr/statuscodewrap_grpc_test.go
+++ b/pkg/orerr/statuscodewrap_grpc_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025 Outreach Corporation. All Rights Reserved.
+
+// Description: Tests for gRPC status and context error classification
+
+package orerr_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/getoutreach/gobox/pkg/orerr"
+	"github.com/getoutreach/gobox/pkg/statuscodes"
+	"gotest.tools/v3/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestExtractErrorStatusCode_GRPCStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected statuscodes.StatusCode
+		category statuscodes.StatusCategory
+	}{
+		{
+			name:     "grpc NotFound direct",
+			err:      status.Error(codes.NotFound, "not found"),
+			expected: statuscodes.NotFound,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc NotFound wrapped",
+			err:      fmt.Errorf("fetching thing: %w", status.Error(codes.NotFound, "not found")),
+			expected: statuscodes.NotFound,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc InvalidArgument",
+			err:      status.Error(codes.InvalidArgument, "bad input"),
+			expected: statuscodes.BadRequest,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc Unauthenticated",
+			err:      status.Error(codes.Unauthenticated, "no auth"),
+			expected: statuscodes.Unauthorized,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc PermissionDenied",
+			err:      status.Error(codes.PermissionDenied, "forbidden"),
+			expected: statuscodes.Forbidden,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc ResourceExhausted",
+			err:      status.Error(codes.ResourceExhausted, "rate limit"),
+			expected: statuscodes.RateLimited,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc DeadlineExceeded",
+			err:      status.Error(codes.DeadlineExceeded, "timeout"),
+			expected: statuscodes.DeadlineExceeded,
+			category: statuscodes.CategoryServerError,
+		},
+		{
+			name:     "grpc Canceled",
+			err:      status.Error(codes.Canceled, "canceled"),
+			expected: statuscodes.Cancelled,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc Internal",
+			err:      status.Error(codes.Internal, "server error"),
+			expected: statuscodes.InternalServerError,
+			category: statuscodes.CategoryServerError,
+		},
+		{
+			name:     "grpc Unavailable",
+			err:      status.Error(codes.Unavailable, "unavailable"),
+			expected: statuscodes.Unavailable,
+			category: statuscodes.CategoryServerError,
+		},
+		{
+			name:     "grpc Unimplemented",
+			err:      status.Error(codes.Unimplemented, "not implemented"),
+			expected: statuscodes.NotImplemented,
+			category: statuscodes.CategoryServerError,
+		},
+		{
+			name:     "grpc AlreadyExists",
+			err:      status.Error(codes.AlreadyExists, "conflict"),
+			expected: statuscodes.Conflict,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc Unknown unmapped",
+			err:      status.Error(codes.Unknown, "unknown"),
+			expected: statuscodes.InternalServerError,
+			category: statuscodes.CategoryServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code := orerr.ExtractErrorStatusCode(tt.err)
+			assert.Equal(t, tt.expected, code, "status code mismatch")
+
+			cat := orerr.ExtractErrorStatusCategory(tt.err)
+			assert.Equal(t, tt.category, cat, "status category mismatch")
+		})
+	}
+}
+
+func TestExtractErrorStatusCode_ContextErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected statuscodes.StatusCode
+		category statuscodes.StatusCategory
+	}{
+		{
+			name:     "context.Canceled direct",
+			err:      context.Canceled,
+			expected: statuscodes.Cancelled,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "context.Canceled wrapped",
+			err:      fmt.Errorf("request failed: %w", context.Canceled),
+			expected: statuscodes.Cancelled,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "context.DeadlineExceeded direct",
+			err:      context.DeadlineExceeded,
+			expected: statuscodes.DeadlineExceeded,
+			category: statuscodes.CategoryServerError,
+		},
+		{
+			name:     "context.DeadlineExceeded wrapped",
+			err:      fmt.Errorf("timed out: %w", context.DeadlineExceeded),
+			expected: statuscodes.DeadlineExceeded,
+			category: statuscodes.CategoryServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code := orerr.ExtractErrorStatusCode(tt.err)
+			assert.Equal(t, tt.expected, code, "status code mismatch")
+
+			cat := orerr.ExtractErrorStatusCategory(tt.err)
+			assert.Equal(t, tt.category, cat, "status category mismatch")
+		})
+	}
+}
+
+func TestExtractErrorStatusCode_StatusCodeWrapperPrecedence(t *testing.T) {
+	grpcErr := status.Error(codes.NotFound, "not found")
+	wrapped := orerr.NewErrorStatus(grpcErr, statuscodes.BadRequest)
+
+	code := orerr.ExtractErrorStatusCode(wrapped)
+	assert.Equal(t, statuscodes.BadRequest, code, "StatusCodeWrapper should take precedence")
+
+	cat := orerr.ExtractErrorStatusCategory(wrapped)
+	assert.Equal(t, statuscodes.CategoryClientError, cat)
+}
+
+func TestExtractErrorStatusCode_PlainError(t *testing.T) {
+	err := fmt.Errorf("plain error")
+
+	code := orerr.ExtractErrorStatusCode(err)
+	assert.Equal(t, statuscodes.InternalServerError, code, "plain error should default to InternalServerError")
+
+	cat := orerr.ExtractErrorStatusCategory(err)
+	assert.Equal(t, statuscodes.CategoryServerError, cat)
+}

--- a/pkg/orerr/statuscodewrap_grpc_test.go
+++ b/pkg/orerr/statuscodewrap_grpc_test.go
@@ -98,6 +98,30 @@ func TestExtractErrorStatusCode_GRPCStatus(t *testing.T) {
 		{
 			name:     "grpc Unknown unmapped",
 			err:      status.Error(codes.Unknown, "unknown"),
+			expected: statuscodes.UnknownError,
+			category: statuscodes.CategoryServerError,
+		},
+		{
+			name:     "grpc FailedPrecondition",
+			err:      status.Error(codes.FailedPrecondition, "precondition failed"),
+			expected: statuscodes.Conflict,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc Aborted",
+			err:      status.Error(codes.Aborted, "transaction aborted"),
+			expected: statuscodes.Conflict,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc OutOfRange",
+			err:      status.Error(codes.OutOfRange, "out of range"),
+			expected: statuscodes.BadRequest,
+			category: statuscodes.CategoryClientError,
+		},
+		{
+			name:     "grpc DataLoss",
+			err:      status.Error(codes.DataLoss, "data loss"),
 			expected: statuscodes.InternalServerError,
 			category: statuscodes.CategoryServerError,
 		},


### PR DESCRIPTION
## What
`orerr.ExtractErrorStatusCode` / `ExtractErrorStatusCategory` previously only recognized `orerr.StatusCodeWrapper` and defaulted everything else to `InternalServerError` / `CategoryServerError`. This means `trace.SetCallError` classified errors carrying a gRPC status (e.g. `status.Errorf(codes.NotFound, ...)`) or `context.Canceled`/`DeadlineExceeded` as server errors in traces/metrics, even though the gRPC wire code returned to clients was correct.

## Changes
- Fallback chain in `ExtractErrorStatusCode`: `StatusCodeWrapper` (unchanged precedence) → `context.Canceled` → `statuscodes.Cancelled` → `context.DeadlineExceeded` → `statuscodes.DeadlineExceeded` → any `GRPCStatus()` error in the chain (via `errors.As`), mapped to the matching `statuscodes` value (inverse of the services/grpcx mapping, plus `AlreadyExists`→`Conflict`) → `InternalServerError` default.
- `ExtractErrorStatusCategory` now derives from the resolved code via `code.Category()`.
- Table tests for gRPC codes, context errors, wrapper precedence, and plain-error fallback.

## Test plan
- [x] `go build ./...`
- [x] `go test -tags or_test ./pkg/orerr/...`
- Note: `pkg/trace` tests fail identically on `origin/main` when run without `make test` ldflags (`modulever` mismatch) — pre-existing, unrelated.

## References
- `interface{ GRPCStatus() *status.Status }` is grpc-go's official error-integration contract, the same one `status.FromError` uses (including `errors.As` chain unwrapping since grpc-go v1.58): [pkg.go.dev/google.golang.org/grpc/status#FromError](https://pkg.go.dev/google.golang.org/grpc/status#FromError), [grpc-go rpc-errors.md](https://github.com/grpc/grpc-go/blob/master/Documentation/rpc-errors.md)
- Service-side counterpart: getoutreach/polaroid#590
