### PR TITLE
fix: allow debug level logs for CLI tools

### DIFF
--- a/pkg/olog/default_handler.go
+++ b/pkg/olog/default_handler.go
@@ -6,6 +6,7 @@
 package olog
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -127,31 +128,23 @@ func createHandler(lr *levelRegistry, m *metadata) slog.Handler {
 	case JSONHandler:
 		h = slog.NewJSONHandler(defaultOut, opts)
 	case TextHandler:
-		// TODO(jaredallard): There's no support for slog.Leveler in the
-		// current charmbracelet/log implementation. So, we can't
-		// dynamically change the logging level yet.
+		// github.com/charmbracelet/log stores its logging level as a
+		// plain field on the *charmlog.Logger, set once via
+		// charmlog.Options.Level or (*charmlog.Logger).SetLevel. It does
+		// not accept a slog.Leveler, so a level can't just be plugged in
+		// and left to be re-evaluated dynamically the way
+		// slog.NewJSONHandler/slog.NewTextHandler do.
 		//
-		// https://github.com/charmbracelet/log/issues/98
-		var charmLogLevel charmlog.Level
-		switch opts.Level.Level() {
-		case slog.LevelDebug:
-			charmLogLevel = charmlog.DebugLevel
-		case slog.LevelInfo:
-			charmLogLevel = charmlog.InfoLevel
-		case slog.LevelWarn:
-			charmLogLevel = charmlog.WarnLevel
-		case slog.LevelError:
-			charmLogLevel = charmlog.ErrorLevel
-		default:
-			panic("unknown slog level")
-		}
-
-		h = charmlog.NewWithOptions(defaultOut, charmlog.Options{
+		// To still honor dynamic level changes (e.g. from
+		// SetGlobalLevel), charmLevelHandler wraps the charm logger and
+		// re-syncs its level from `opts.Level` (our slog.Leveler) on
+		// every call to Enabled, which slog always calls before Handle.
+		h = newCharmLevelHandler(charmlog.NewWithOptions(defaultOut, charmlog.Options{
 			ReportTimestamp: true,
 			TimeFormat:      "15:04:05",
 			ReportCaller:    opts.AddSource,
-			Level:           charmLogLevel,
-		})
+			Level:           charmlog.Level(opts.Level.Level()),
+		}), opts.Level)
 	default:
 		panic("unknown default handler")
 	}
@@ -179,3 +172,63 @@ func replaceKey(oldKey, newKey string) func([]string, slog.Attr) slog.Attr {
 		return a
 	}
 }
+
+// charmLevelHandler is a slog.Handler that wraps a *charmlog.Logger in
+// order to make it respect a slog.Leveler dynamically.
+//
+// charmlog.Logger implements slog.Handler, but its own Enabled/Handle
+// methods only consult a level set once via charmlog.Options.Level or
+// (*charmlog.Logger).SetLevel -- it has no concept of a slog.Leveler
+// that could be re-evaluated on every log call. So a *charmlog.Logger
+// on its own can't pick up changes made after it was created (e.g. via
+// SetGlobalLevel), which is a problem for `log` package-level
+// singletons that are created well before a program has parsed its
+// configuration/flags and decided what level it wants.
+//
+// charmLevelHandler works around this by re-syncing the wrapped
+// logger's level from `leveler` every time Enabled is called (which
+// slog always does immediately before Handle for a given record), so
+// the charm logger's level is always brought up to date before it
+// gets a chance to reject or accept the record.
+type charmLevelHandler struct {
+	inner   *charmlog.Logger
+	leveler slog.Leveler
+}
+
+// newCharmLevelHandler creates a charmLevelHandler that wraps inner and
+// keeps its level synced with leveler.
+func newCharmLevelHandler(inner *charmlog.Logger, leveler slog.Leveler) *charmLevelHandler {
+	return &charmLevelHandler{inner: inner, leveler: leveler}
+}
+
+// Enabled implements slog.Handler. It re-syncs the wrapped charm
+// logger's level from `leveler` before reporting whether the given
+// level is enabled.
+func (h *charmLevelHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	h.inner.SetLevel(charmlog.Level(h.leveler.Level()))
+	return h.inner.Enabled(ctx, level)
+}
+
+// Handle implements slog.Handler by delegating to the wrapped charm
+// logger. Enabled will always have been called (and will have synced
+// the level) immediately prior, per the slog.Handler contract.
+//
+//nolint:gocritic // Why: Handle's signature is fixed by the slog.Handler interface.
+func (h *charmLevelHandler) Handle(ctx context.Context, r slog.Record) error {
+	return h.inner.Handle(ctx, r)
+}
+
+// WithAttrs implements slog.Handler.
+func (h *charmLevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	//nolint:forcetypeassert // Why: (*charmlog.Logger).WithAttrs always returns a *charmlog.Logger.
+	return &charmLevelHandler{inner: h.inner.WithAttrs(attrs).(*charmlog.Logger), leveler: h.leveler}
+}
+
+// WithGroup implements slog.Handler.
+func (h *charmLevelHandler) WithGroup(name string) slog.Handler {
+	//nolint:forcetypeassert // Why: (*charmlog.Logger).WithGroup always returns a *charmlog.Logger.
+	return &charmLevelHandler{inner: h.inner.WithGroup(name).(*charmlog.Logger), leveler: h.leveler}
+}
+
+// _ ensures charmLevelHandler implements slog.Handler.
+var _ slog.Handler = (*charmLevelHandler)(nil)

--- a/pkg/olog/default_handler.go
+++ b/pkg/olog/default_handler.go
@@ -128,17 +128,8 @@ func createHandler(lr *levelRegistry, m *metadata) slog.Handler {
 	case JSONHandler:
 		h = slog.NewJSONHandler(defaultOut, opts)
 	case TextHandler:
-		// github.com/charmbracelet/log stores its logging level as a
-		// plain field on the *charmlog.Logger, set once via
-		// charmlog.Options.Level or (*charmlog.Logger).SetLevel. It does
-		// not accept a slog.Leveler, so a level can't just be plugged in
-		// and left to be re-evaluated dynamically the way
-		// slog.NewJSONHandler/slog.NewTextHandler do.
-		//
-		// To still honor dynamic level changes (e.g. from
-		// SetGlobalLevel), charmLevelHandler wraps the charm logger and
-		// re-syncs its level from `opts.Level` (our slog.Leveler) on
-		// every call to Enabled, which slog always calls before Handle.
+		// charmlog.Logger doesn't support slog.Leveler, so wrap it in
+		// charmLevelHandler to keep its level in sync dynamically.
 		h = newCharmLevelHandler(charmlog.NewWithOptions(defaultOut, charmlog.Options{
 			ReportTimestamp: true,
 			TimeFormat:      "15:04:05",
@@ -173,23 +164,10 @@ func replaceKey(oldKey, newKey string) func([]string, slog.Attr) slog.Attr {
 	}
 }
 
-// charmLevelHandler is a slog.Handler that wraps a *charmlog.Logger in
-// order to make it respect a slog.Leveler dynamically.
-//
-// charmlog.Logger implements slog.Handler, but its own Enabled/Handle
-// methods only consult a level set once via charmlog.Options.Level or
-// (*charmlog.Logger).SetLevel -- it has no concept of a slog.Leveler
-// that could be re-evaluated on every log call. So a *charmlog.Logger
-// on its own can't pick up changes made after it was created (e.g. via
-// SetGlobalLevel), which is a problem for `log` package-level
-// singletons that are created well before a program has parsed its
-// configuration/flags and decided what level it wants.
-//
-// charmLevelHandler works around this by re-syncing the wrapped
-// logger's level from `leveler` every time Enabled is called (which
-// slog always does immediately before Handle for a given record), so
-// the charm logger's level is always brought up to date before it
-// gets a chance to reject or accept the record.
+// charmLevelHandler wraps a *charmlog.Logger to make it respect a
+// slog.Leveler dynamically. charmlog.Logger only supports a level set
+// once at creation (or via SetLevel), so this re-syncs it from
+// `leveler` on every call to Enabled.
 type charmLevelHandler struct {
 	inner   *charmlog.Logger
 	leveler slog.Leveler
@@ -209,9 +187,7 @@ func (h *charmLevelHandler) Enabled(ctx context.Context, level slog.Level) bool 
 	return h.inner.Enabled(ctx, level)
 }
 
-// Handle implements slog.Handler by delegating to the wrapped charm
-// logger. Enabled will always have been called (and will have synced
-// the level) immediately prior, per the slog.Handler contract.
+// Handle implements slog.Handler by delegating to the wrapped logger.
 //
 //nolint:gocritic // Why: Handle's signature is fixed by the slog.Handler interface.
 func (h *charmLevelHandler) Handle(ctx context.Context, r slog.Record) error {

--- a/pkg/olog/olog_test.go
+++ b/pkg/olog/olog_test.go
@@ -147,16 +147,8 @@ func TestOutputLog(t *testing.T) {
 	}
 }
 
-// TestTextHandlerRespectsDynamicLevel ensures that loggers using the
-// TextHandler (backed by charm.land/log/v2) respect log-level changes
-// made via SetGlobalLevel *after* the logger has already been created.
-//
-// This is a regression test: charmlog.Logger does not implement
-// slog.Leveler, it only supports a level set once at creation (or via
-// SetLevel). createHandler wraps it in charmLevelHandler specifically
-// to keep it in sync with the leveler dynamically -- without that
-// wrapper, this test would fail because the DEBUG line logged after
-// SetGlobalLevel would not appear.
+// TestTextHandlerRespectsDynamicLevel ensures TextHandler loggers
+// respect SetGlobalLevel changes made after the logger was created.
 func TestTextHandlerRespectsDynamicLevel(t *testing.T) {
 	t.Cleanup(func() {
 		SetDefaultHandler(JSONHandler)

--- a/pkg/olog/olog_test.go
+++ b/pkg/olog/olog_test.go
@@ -1,6 +1,7 @@
 package olog
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"os"
@@ -143,5 +144,49 @@ func TestOutputLog(t *testing.T) {
 	}
 	if !strings.Contains(string(data), testLogLine) {
 		t.Fatalf("Expect to find '%s', but got %s\n", testLogLine, string(data))
+	}
+}
+
+// TestTextHandlerRespectsDynamicLevel ensures that loggers using the
+// TextHandler (backed by charm.land/log/v2) respect log-level changes
+// made via SetGlobalLevel *after* the logger has already been created.
+//
+// This is a regression test: charmlog.Logger does not implement
+// slog.Leveler, it only supports a level set once at creation (or via
+// SetLevel). createHandler wraps it in charmLevelHandler specifically
+// to keep it in sync with the leveler dynamically -- without that
+// wrapper, this test would fail because the DEBUG line logged after
+// SetGlobalLevel would not appear.
+func TestTextHandlerRespectsDynamicLevel(t *testing.T) {
+	t.Cleanup(func() {
+		SetDefaultHandler(JSONHandler)
+		SetGlobalLevel(slog.LevelInfo)
+		defaultOut = os.Stderr
+	})
+
+	SetDefaultHandler(TextHandler)
+
+	buf := &bytes.Buffer{}
+	defaultOut = buf
+
+	lr := newRegistry()
+	logger := NewWithHandler(createHandler(lr, &metadata{ModulePath: "testModuleName", PackagePath: "testPackageName"}))
+
+	SetGlobalLevel(slog.LevelInfo)
+	logger.Debug("should NOT appear (level=info)")
+	logger.Info("should appear (level=info)")
+
+	SetGlobalLevel(slog.LevelDebug)
+	logger.Debug("should appear now (level=debug, set after logger creation)")
+
+	out := buf.String()
+	if strings.Contains(out, "should NOT appear") {
+		t.Fatalf("expected debug log below the level to be suppressed, got:\n%s", out)
+	}
+	if !strings.Contains(out, "should appear (level=info)") {
+		t.Fatalf("expected info log to appear, got:\n%s", out)
+	}
+	if !strings.Contains(out, "should appear now") {
+		t.Fatalf("expected debug log after SetGlobalLevel(Debug) to appear, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

CLI tools like [smartstorectl](https://github.com/getoutreach/smartstorectl/blob/main/internal/tunnel/tunnel.go#L43) use TextHandler when executed in TTY. They accept `--loglevel debug` but do not honor it because there is no way how to change the log level globally for already created `charmbracelet/log` logger instances. And they are usually created in the init phase before the `main()` code executes and arguments are processed. 

The linked [issue](https://github.com/charmbracelet/log/issues/98) was closed as a won't fix and if I understood correctly this was suggested as a solution. It's ugly but it works well. 

Of course, it will need a code change in every tool using it. After parsing `--loglevel` for `logrus` the script will need to update `olog` as well for example [here](https://github.com/getoutreach/smartstorectl/blob/main/cmd/smartstorectl/psql/commands.go#L73) like this:

```
				var level slog.Level
				if err := level.UnmarshalText([]byte(lvl)); err != nil {
					return err
				}
				olog.SetGlobalLevel(level)
				return nil
```


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

`charmlog.Logger` implements `slog.Handler`, but its `Enabled`/`Handle` methods only consult a level set once via `charmlog.Options.Level` or `(*charmlog.Logger).SetLevel` — it has no concept of a `slog.Leveler` that gets re-evaluated on every log call. So a bare `*charmlog.Logger` can't pick up level changes made after it was created (e.g. via `SetGlobalLevel`), which is exactly the problem for `olog`'s package-level `log` singletons that are created well before a program parses its flags.

`charmLevelHandler` (in `pkg/olog/default_handler.go`) works around this by wrapping the `*charmlog.Logger` and re-syncing its level from our own `slog.Leveler` every time `Enabled` is called — which `slog` always does immediately before `Handle` for a given record — so the wrapped logger's level is always brought up to date before it gets a chance to reject or accept the record.

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
